### PR TITLE
use the navigator language rather than the doc lang attribute

### DIFF
--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -23,10 +23,7 @@ cozy.init({
 })
 
 const context = window.context
-let lang = document.documentElement.getAttribute('lang') || 'en'
-if (navigator && navigator.language) {
-  lang = navigator.language.slice(0, 2)
-}
+const lang = (navigator && navigator.language) ? navigator.language.slice(0, 2) : 'en'
 
 const loggerMiddleware = createLogger()
 


### PR DESCRIPTION
I found that `index.ejs` set the lang attribute (`<html lang="en">`) and the application use this lang attribute to translate the application.

In cordova, we could get the navigator language that uses the up-to-date user's language preference.
The format is `fr-FR` or `en-US`, so we could `slice(0,2)` to get `fr` or `en`.

I don't know if the web application is well translated but with this PR, the mobile application will be.