### PR TITLE
useful serve task

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "watch": "webpack --config webpack.config.js --watch --display-modules --display-chunks",
     "watch:browser": "NODE_ENV=browser:development npm run watch",
     "watch:mobile": "NODE_ENV=mobile:development npm run watch",
-    "watch:standalone": "NODE_ENV=browser:development webpack-dev-server --config webpack.config.js --port 8082 --display-modules --display-chunks --inline --hot"
+    "serve:browser": "NODE_ENV=browser:development webpack-dev-server --config webpack.config.js --port 8082 --display-modules --display-chunks --inline --hot",
+    "serve:mobile": "NODE_ENV=mobile:development webpack-dev-server --config webpack.config.js --port 8082 --display-modules --display-chunks --inline --hot"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
My workflow for android development is:

- I run a cozy-stack container with `docker run --rm -it -p 8080:8080 cozy/cozy-app-dev`
- I serve `mobile/www` with a watch task: `yarn serve:mobile`
- I debug on chromium
OR
- I deploy what is built in `mobile/www` on a mobile phone with `cordova run android --device` (be sure to `cd mobile` first)

Very useful!