### PR TITLE
chore: postcss-loader's warning about sourcemaps

### DIFF
--- a/config/webpack.config.cozy-ui.js
+++ b/config/webpack.config.cozy-ui.js
@@ -2,7 +2,7 @@
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
-module.exports = (production) => ({
+module.exports = production => ({
   resolve: {
     extensions: ['.styl']
   },
@@ -38,6 +38,7 @@ module.exports = (production) => ({
             {
               loader: 'stylus-loader',
               options: {
+                sourceMap: !production,
                 use: [require('cozy-ui/stylus')()]
               }
             }


### PR DESCRIPTION
fix the following postcss-loader warning:

---

⚠️  PostCSS Loader

Previous source map found, but options.sourceMap isn't set.
In this case the loader will discard the source map entirely for performance reasons.
See https://github.com/postcss/postcss-loader\#sourcemap for more information.

---

