### PR TITLE
Don't return null from the viewer if the folder contains a lot of folders and no files are fetched at first

### DIFF
--- a/src/drive/components/FilesViewer.jsx
+++ b/src/drive/components/FilesViewer.jsx
@@ -85,7 +85,6 @@ class FilesViewer extends Component {
 
   render() {
     const files = this.getViewableFiles()
-    if (files.length === 0) return null
     const currentIndex = this.getCurrentIndex(files)
     // If we can't find the file, we fallback to the (potentially loading)
     // direct stat made by the viewer


### PR DESCRIPTION
Another quick fix after testing on recette: if we click on a search result that comes from a folder with 30+ folders, no files are loaded at first, and so the viewer doesn't show. 

Merged without review to save time considering its triviality.