### PR TITLE
Removed unwanted Alerter call in NoViewer

### DIFF
--- a/src/viewer/NoViewer.jsx
+++ b/src/viewer/NoViewer.jsx
@@ -74,7 +74,6 @@ class NoViewer extends React.Component {
     error: null
   }
   render() {
-    Alerter.error('Viewer.error.noapp')
     const { t, file, fallbackUrl = false } = this.props
     return (
       <div


### PR DESCRIPTION
This call has been added by error during the `Alerter` transition, and being in the render method, it notifies the user repeatedly of an error when opening a PDF.