### PR TITLE
fix: client queryS being called without an id ( query options )

### DIFF
--- a/jestHelpers/setup.js
+++ b/jestHelpers/setup.js
@@ -2,6 +2,27 @@ import React from 'react'
 
 global.cozy = {}
 
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: {
+      get: jest.fn(name => {
+        if (name.toLowerCase() === 'content-type') {
+          return 'application/json'
+        }
+        return null
+      })
+    },
+    json: async () => ({
+      rows: [],
+      data: []
+    }),
+    text: async () => '',
+    blob: async () => new Blob()
+  })
+)
+
 jest.mock('cozy-bar', () => ({
   ...jest.requireActual('cozy-bar'),
   BarComponent: () => <div>Bar</div>,

--- a/src/components/FolderPicker/FolderPickerHeader.spec.js
+++ b/src/components/FolderPicker/FolderPickerHeader.spec.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import React from 'react'
 
 import CozyClient from 'cozy-client'
@@ -11,7 +11,7 @@ jest.mock('lib/logger', () => ({
 }))
 
 describe('FolderPickerHeader', () => {
-  const setupComponent = ({ entries = [], title, subTitle }) => {
+  const setupComponent = async ({ entries = [], title, subTitle }) => {
     const props = {
       entries,
 
@@ -20,26 +20,30 @@ describe('FolderPickerHeader', () => {
     }
     const client = new CozyClient({})
 
-    return render(
-      <AppLike client={client}>
-        <FolderPickerHeader {...props} />
-      </AppLike>
-    )
+    let component
+    await act(async () => {
+      component = render(
+        <AppLike client={client}>
+          <FolderPickerHeader {...props} />
+        </AppLike>
+      )
+    })
+    return component
   }
-  it('should fallback to Move title if no title is given', () => {
-    const { getByText } = setupComponent({
+  it('should fallback to Move title if no title is given', async () => {
+    const { getByText } = await setupComponent({
       entries: [{ file: 1 }, { file: 2 }]
     })
     expect(getByText('2 elements'))
   })
-  it('should display title if title is given and no file', () => {
-    const { getByText } = setupComponent({
+  it('should display title if title is given and no file', async () => {
+    const { getByText } = await setupComponent({
       title: 'My Title'
     })
     expect(getByText('My Title'))
   })
-  it('should display the right title if only one io.cozy.files', () => {
-    const { getByText } = setupComponent({
+  it('should display the right title if only one io.cozy.files', async () => {
+    const { getByText } = await setupComponent({
       title: 'My Title',
       entries: [
         {
@@ -51,8 +55,8 @@ describe('FolderPickerHeader', () => {
     expect(getByText('FileName.txt'))
   })
 
-  it('should display the right title if it comes from the outside', () => {
-    const { getByText } = setupComponent({
+  it('should display the right title if it comes from the outside', async () => {
+    const { getByText } = await setupComponent({
       title: 'My Title',
       entries: [
         {
@@ -62,8 +66,8 @@ describe('FolderPickerHeader', () => {
     })
     expect(getByText('FileName.txt'))
   })
-  it('should display the right title if more than one files', () => {
-    const { getByText } = setupComponent({
+  it('should display the right title if more than one files', async () => {
+    const { getByText } = await setupComponent({
       title: 'My Title',
       entries: [
         {

--- a/src/hooks/useFolderSort/index.spec.jsx
+++ b/src/hooks/useFolderSort/index.spec.jsx
@@ -1,23 +1,28 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
 
 import { useFolderSort } from './index'
 
 import { DEFAULT_SORT, SORT_BY_UPDATE_DATE } from '@/config/sort'
 import { TRASH_DIR_ID } from '@/constants/config'
-import { DOCTYPE_DRIVE_SETTINGS } from '@/lib/doctypes'
 import logger from '@/lib/logger'
 import { usePublicContext } from '@/modules/public/PublicProvider'
 
 jest.mock('cozy-client', () => ({
   useClient: jest.fn(),
-  Q: jest.fn().mockReturnValue('mocked-query'),
   useQuery: jest.fn()
 }))
 
 jest.mock('cozy-flags', () => jest.fn())
+
+jest.mock('@/queries', () => ({
+  getDriveSettingQuery: {
+    definition: jest.fn(),
+    options: { as: 'io.cozy.drive.settings' }
+  }
+}))
 
 jest.mock('@/lib/logger', () => ({
   warn: jest.fn(),
@@ -30,6 +35,7 @@ jest.mock('@/modules/public/PublicProvider', () => ({
 }))
 
 const mockUseClient = useClient
+const mockUseQuery = useQuery
 const mockFlag = flag
 const mockUsePublicContext = usePublicContext
 
@@ -43,10 +49,10 @@ describe('useFolderSort', () => {
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     mockClient = {
-      save: jest.fn().mockResolvedValue({}),
-      query: jest.fn().mockResolvedValue({ data: [] })
+      save: jest.fn().mockResolvedValue({})
     }
     mockUseClient.mockReturnValue(mockClient)
+    mockUseQuery.mockReturnValue({ data: [] })
 
     mockFlag.mockImplementation(flagName => {
       if (flagName === 'drive.save-sort-choice.enabled') {
@@ -67,9 +73,7 @@ describe('useFolderSort', () => {
   describe('default sort behavior', () => {
     it('should use DEFAULT_SORT for regular folders', () => {
       const folderId = 'regular-folder-id'
-      mockClient.query.mockResolvedValue({
-        data: []
-      })
+      mockUseQuery.mockReturnValue({ data: [] })
 
       const { result } = renderHook(() => useFolderSort(folderId))
 
@@ -79,9 +83,7 @@ describe('useFolderSort', () => {
 
     it('should use SORT_BY_UPDATE_DATE for trash folder', () => {
       const folderId = TRASH_DIR_ID
-      mockClient.query.mockResolvedValue({
-        data: []
-      })
+      mockUseQuery.mockReturnValue({ data: [] })
 
       const { result } = renderHook(() => useFolderSort(folderId))
 
@@ -91,9 +93,7 @@ describe('useFolderSort', () => {
 
     it('should use SORT_BY_UPDATE_DATE for recent folder', () => {
       const folderId = 'recent'
-      mockClient.query.mockResolvedValue({
-        data: []
-      })
+      mockUseQuery.mockReturnValue({ data: [] })
 
       const { result } = renderHook(() => useFolderSort(folderId))
 
@@ -103,26 +103,22 @@ describe('useFolderSort', () => {
   })
 
   describe('loading existing sorting settings', () => {
-    it('should load and apply existing sorting settings when available', async () => {
+    it('should load and apply existing sorting settings when available', () => {
       const folderId = 'test-folder'
       const existingSettings = {
         _id: 'settings-id',
-        _type: DOCTYPE_DRIVE_SETTINGS,
+        _type: 'io.cozy.drive.settings',
         attributes: {
           attribute: 'updated_at',
           order: 'desc'
         }
       }
 
-      mockClient.query.mockResolvedValue({
+      mockUseQuery.mockReturnValue({
         data: [existingSettings]
       })
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useFolderSort(folderId)
-      )
-
-      await waitForNextUpdate()
+      const { result } = renderHook(() => useFolderSort(folderId))
 
       const [currentSort] = result.current
       expect(currentSort).toEqual({
@@ -135,10 +131,10 @@ describe('useFolderSort', () => {
       const folderId = 'test-folder'
       const existingSettings = {
         _id: 'settings-id',
-        _type: DOCTYPE_DRIVE_SETTINGS
+        _type: 'io.cozy.drive.settings'
       }
 
-      mockClient.query.mockResolvedValue({
+      mockUseQuery.mockReturnValue({
         data: [existingSettings]
       })
 
@@ -148,26 +144,22 @@ describe('useFolderSort', () => {
       expect(currentSort).toEqual(DEFAULT_SORT)
     })
 
-    it('should return consistent sort values on multiple renders', async () => {
+    it('should return consistent sort values on multiple renders', () => {
       const folderId = 'test-folder'
       const existingSettings = {
         _id: 'settings-id',
-        _type: DOCTYPE_DRIVE_SETTINGS,
+        _type: 'io.cozy.drive.settings',
         attributes: {
           attribute: 'name',
           order: 'asc'
         }
       }
 
-      mockClient.query.mockResolvedValue({
+      mockUseQuery.mockReturnValue({
         data: [existingSettings]
       })
 
-      const { result, rerender, waitForNextUpdate } = renderHook(() =>
-        useFolderSort(folderId)
-      )
-
-      await waitForNextUpdate()
+      const { result, rerender } = renderHook(() => useFolderSort(folderId))
 
       const [firstSort] = result.current
       expect(firstSort).toEqual({
@@ -190,9 +182,7 @@ describe('useFolderSort', () => {
       const folderId = 'test-folder'
       const newSort = { attribute: 'updated_at', order: 'desc' }
 
-      mockClient.query.mockResolvedValue({
-        data: []
-      })
+      mockUseQuery.mockReturnValue({ data: [] })
 
       const { result } = renderHook(() => useFolderSort(folderId))
 
@@ -202,9 +192,8 @@ describe('useFolderSort', () => {
       })
 
       expect(mockClient.save).toHaveBeenCalledWith({
-        _type: DOCTYPE_DRIVE_SETTINGS,
+        _type: 'io.cozy.drive.settings',
         attributes: {
-          ...DEFAULT_SORT,
           attribute: 'updated_at',
           order: 'desc'
         }
@@ -220,7 +209,7 @@ describe('useFolderSort', () => {
       const folderId = 'test-folder'
       const existingSettings = {
         _id: 'settings-id',
-        _type: DOCTYPE_DRIVE_SETTINGS,
+        _type: 'io.cozy.drive.settings',
         attributes: {
           attribute: 'name',
           order: 'asc'
@@ -228,16 +217,11 @@ describe('useFolderSort', () => {
       }
       const newSort = { attribute: 'updated_at', order: 'desc' }
 
-      mockClient.query.mockResolvedValue({
+      mockUseQuery.mockReturnValue({
         data: [existingSettings]
       })
 
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useFolderSort(folderId)
-      )
-
-      // Wait for the settings to load
-      await waitForNextUpdate()
+      const { result } = renderHook(() => useFolderSort(folderId))
 
       const [, setSortOrder] = result.current
       await act(async () => {
@@ -264,9 +248,7 @@ describe('useFolderSort', () => {
       const saveError = new Error('Save failed')
 
       mockClient.save.mockRejectedValue(saveError)
-      mockClient.query.mockResolvedValue({
-        data: []
-      })
+      mockUseQuery.mockReturnValue({ data: [] })
 
       const { result } = renderHook(() => useFolderSort(folderId))
 
@@ -283,11 +265,11 @@ describe('useFolderSort', () => {
   })
 
   describe('public context behavior', () => {
-    it('should not load settings in public view', async () => {
+    it('should not load settings in public view', () => {
       const folderId = 'test-folder'
       const existingSettings = {
         _id: 'settings-id',
-        _type: DOCTYPE_DRIVE_SETTINGS,
+        _type: 'io.cozy.drive.settings',
         attributes: {
           attribute: 'updated_at',
           order: 'desc'
@@ -298,7 +280,7 @@ describe('useFolderSort', () => {
         isPublic: true
       })
 
-      mockClient.query.mockResolvedValue({
+      mockUseQuery.mockReturnValue({
         data: [existingSettings]
       })
 
@@ -307,8 +289,6 @@ describe('useFolderSort', () => {
       const [currentSort] = result.current
 
       expect(currentSort).toEqual(DEFAULT_SORT)
-
-      expect(mockClient.query).not.toHaveBeenCalled()
     })
 
     it('should not persist settings in public view', async () => {
@@ -331,8 +311,6 @@ describe('useFolderSort', () => {
       )
 
       expect(mockClient.save).not.toHaveBeenCalled()
-
-      expect(mockClient.query).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/hooks/useFolderSort/index.spec.jsx
+++ b/src/hooks/useFolderSort/index.spec.jsx
@@ -242,6 +242,40 @@ describe('useFolderSort', () => {
       )
     })
 
+    it('should preserve other attributes when updating sorting settings', async () => {
+      const folderId = 'test-folder'
+      const existingSettings = {
+        _id: 'settings-id',
+        _type: 'io.cozy.drive.settings',
+        attributes: {
+          attribute: 'name',
+          order: 'asc',
+          preferredDriveViewType: 'grid'
+        }
+      }
+      const newSort = { attribute: 'updated_at', order: 'desc' }
+
+      mockUseQuery.mockReturnValue({
+        data: [existingSettings]
+      })
+
+      const { result } = renderHook(() => useFolderSort(folderId))
+
+      const [, setSortOrder] = result.current
+      await act(async () => {
+        await setSortOrder(newSort)
+      })
+
+      expect(mockClient.save).toHaveBeenCalledWith({
+        ...existingSettings,
+        attributes: {
+          attribute: 'updated_at',
+          order: 'desc',
+          preferredDriveViewType: 'grid'
+        }
+      })
+    })
+
     it('should handle save errors gracefully', async () => {
       const folderId = 'test-folder'
       const newSort = { attribute: 'updated_at', order: 'desc' }

--- a/src/hooks/useFolderSort/index.ts
+++ b/src/hooks/useFolderSort/index.ts
@@ -77,15 +77,15 @@ const useFolderSort = (
       setIsSaving(true)
 
       try {
-        const settingsToSave: DriveSettings = settingsQuery.data?.length
-          ? {
-              ...settingsQuery.data[0],
-              attributes: { attribute, order }
-            }
-          : {
-              _type: 'io.cozy.drive.settings',
-              attributes: { attribute, order }
-            }
+        const existing = settingsQuery.data?.[0]
+        const settingsToSave = {
+          ...(existing || { _type: 'io.cozy.drive.settings' }),
+          attributes: {
+            ...(existing?.attributes || {}),
+            attribute,
+            order
+          }
+        }
 
         await client.save(settingsToSave)
         logger.info('Sort settings persisted', { attribute, order })

--- a/src/lib/ViewSwitcherContext.tsx
+++ b/src/lib/ViewSwitcherContext.tsx
@@ -3,8 +3,8 @@ import React, { useState, useContext, createContext, useEffect } from 'react'
 import { useClient, useQuery } from 'cozy-client'
 
 import logger from './logger'
-import { getAppSettingQuery } from '@/queries'
-import { DOCTYPE_FILES_SETTINGS } from '@/lib/doctypes'
+import { getDriveSettingQuery } from '@/queries'
+import { DOCTYPE_DRIVE_SETTINGS } from '@/lib/doctypes'
 
 interface QueryResult {
   data: [
@@ -32,8 +32,8 @@ const ViewSwitcherContextProvider: React.FC = ({ children }) => {
   const client = useClient()
   const [viewType, setViewType] = useState(DEFAULT_VIEW_TYPE)
   const settingsQuery = useQuery(
-    getAppSettingQuery.definition,
-    getAppSettingQuery.options
+    getDriveSettingQuery.definition,
+    getDriveSettingQuery.options
   ) as QueryResult
 
   useEffect(() => {
@@ -55,7 +55,7 @@ const ViewSwitcherContextProvider: React.FC = ({ children }) => {
       const existing = settingsQuery.data?.[0]
 
       await client.save({
-        ...(existing || { _type: DOCTYPE_FILES_SETTINGS }),
+        ...(existing || { _type: DOCTYPE_DRIVE_SETTINGS }),
         attributes: {
           ...(existing?.attributes || {}),
           preferredDriveViewType: viewTypeParam

--- a/src/modules/drive/RenameInput.spec.jsx
+++ b/src/modules/drive/RenameInput.spec.jsx
@@ -18,6 +18,14 @@ jest.mock('cozy-ui/transpiled/react/providers/Alert', () => ({
   useAlert: jest.fn()
 }))
 
+jest.mock('@/lib/ViewSwitcherContext', () => ({
+  ViewSwitcherContextProvider: ({ children }) => children,
+  useViewSwitcherContext: jest.fn(() => ({
+    viewType: 'list',
+    switchView: jest.fn()
+  }))
+}))
+
 describe('RenameInput', () => {
   let client
   let onAbort

--- a/src/modules/drive/Toolbar/delete/DeleteItem.spec.jsx
+++ b/src/modules/drive/Toolbar/delete/DeleteItem.spec.jsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, act } from '@testing-library/react'
 import React from 'react'
 
 import DeleteItem from './DeleteItem'
@@ -15,7 +15,7 @@ jest.mock('lib/logger', () => ({
 }))
 
 describe('DeleteItem', () => {
-  const setup = () => {
+  const setup = async () => {
     const displayedFolder = {
       _id: 'displayed-folder-id',
       name: 'My Folder'
@@ -24,20 +24,23 @@ describe('DeleteItem', () => {
 
     jest.spyOn(store, 'dispatch')
     const onLeave = jest.fn()
-    const container = render(
-      <AppLike client={client} store={store}>
-        <DeleteItem
-          isSharedWithMe={false}
-          onLeave={onLeave}
-          displayedFolder={displayedFolder}
-        />
-      </AppLike>
-    )
+    let container
+    await act(async () => {
+      container = render(
+        <AppLike client={client} store={store}>
+          <DeleteItem
+            isSharedWithMe={false}
+            onLeave={onLeave}
+            displayedFolder={displayedFolder}
+          />
+        </AppLike>
+      )
+    })
     return { container, store, displayedFolder }
   }
 
   it('should show a modal', async () => {
-    const { container, store, displayedFolder } = setup()
+    const { container, store, displayedFolder } = await setup()
     const confirmButton = container.getByText('Remove')
     fireEvent.click(confirmButton)
     expect(store.dispatch).toHaveBeenCalledWith(

--- a/src/modules/drive/Toolbar/delete/delete.spec.jsx
+++ b/src/modules/drive/Toolbar/delete/delete.spec.jsx
@@ -16,6 +16,14 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate
 }))
 
+jest.mock('@/lib/ViewSwitcherContext', () => ({
+  ViewSwitcherContextProvider: ({ children }) => children,
+  useViewSwitcherContext: jest.fn(() => ({
+    viewType: 'list',
+    switchView: jest.fn()
+  }))
+}))
+
 describe('EnhancedDeleteConfirm', () => {
   const setup = () => {
     const folder = {

--- a/src/modules/filelist/AddFolder.spec.jsx
+++ b/src/modules/filelist/AddFolder.spec.jsx
@@ -20,6 +20,14 @@ jest.mock('cozy-keys-lib', () => ({
   WebVaultClient: jest.fn().mockReturnValue({})
 }))
 
+jest.mock('@/lib/ViewSwitcherContext', () => ({
+  ViewSwitcherContextProvider: ({ children }) => children,
+  useViewSwitcherContext: jest.fn(() => ({
+    viewType: 'list',
+    switchView: jest.fn()
+  }))
+}))
+
 describe('AddFolder', () => {
   const setup = () => {
     const { client, store } = setupStoreAndClient({})

--- a/src/modules/viewer/FilesViewer.spec.jsx
+++ b/src/modules/viewer/FilesViewer.spec.jsx
@@ -33,6 +33,14 @@ jest.mock('cozy-viewer', () => ({
   default: () => <div>Viewer</div>
 }))
 
+jest.mock('@/lib/ViewSwitcherContext', () => ({
+  ViewSwitcherContextProvider: ({ children }) => children,
+  useViewSwitcherContext: jest.fn(() => ({
+    viewType: 'list',
+    switchView: jest.fn()
+  }))
+}))
+
 const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
 
 describe('FilesViewer', () => {

--- a/src/modules/viewer/FilesViewer.spec.jsx
+++ b/src/modules/viewer/FilesViewer.spec.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import React from 'react'
 
 import CozyClient, { useQuery } from 'cozy-client'
@@ -123,15 +123,17 @@ describe('FilesViewer', () => {
 
     const hasMore = jest.fn().mockReturnValue(true)
 
-    setup({
-      client,
-      nbFiles: 50,
-      totalCount: 100,
-      fileId: 'file-foobar48',
-      useQueryResultAttributes: {
-        fetchMore,
-        hasMore
-      }
+    await act(async () => {
+      setup({
+        client,
+        nbFiles: 50,
+        totalCount: 100,
+        fileId: 'file-foobar48',
+        useQueryResultAttributes: {
+          fetchMore,
+          hasMore
+        }
+      })
     })
 
     const viewer = await screen.findByText('Viewer')

--- a/src/modules/views/OnlyOffice/Editor.spec.jsx
+++ b/src/modules/views/OnlyOffice/Editor.spec.jsx
@@ -44,6 +44,14 @@ jest.mock('cozy-viewer', () => ({
   default: () => <div data-testid="ViewerForTest" />
 }))
 
+jest.mock('@/lib/ViewSwitcherContext', () => ({
+  ViewSwitcherContextProvider: ({ children }) => children,
+  useViewSwitcherContext: jest.fn(() => ({
+    viewType: 'list',
+    switchView: jest.fn()
+  }))
+}))
+
 const client = createMockClient({})
 client.plugins = {
   realtime: {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -5,7 +5,8 @@ import { SHARED_DRIVES_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
 import {
   DOCTYPE_FILES_ENCRYPTION,
   DOCTYPE_ALBUMS,
-  DOCTYPE_FILES_SETTINGS
+  DOCTYPE_FILES_SETTINGS,
+  DOCTYPE_DRIVE_SETTINGS
 } from '@/lib/doctypes'
 import { formatFolderQueryId } from '@/lib/queries'
 
@@ -632,3 +633,15 @@ export const buildSharedDriveIdQuery: QueryBuilder<
     enabled: !!driveId
   }
 })
+
+/**
+ * Drive application settings query
+ *
+ * @type {QueryConfig}
+ */
+export const getDriveSettingQuery: QueryConfig = {
+  definition: () => Q(DOCTYPE_DRIVE_SETTINGS),
+  options: {
+    as: DOCTYPE_DRIVE_SETTINGS
+  }
+}


### PR DESCRIPTION
### what's changed
- added the getDriveSettingQuery for io.cozy.drive.settings queries
- used getDriveSettingQuery in saving sort choice
- fixed switch context view using rogue query ( without an id )
