### PR TITLE
feat: Remove defer from script tag

### DIFF
--- a/src/targets/browser/index.ejs
+++ b/src/targets/browser/index.ejs
@@ -35,7 +35,7 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div role="application" data-cozy="{{.CozyData}}"></div>
     <% htmlPlugin.files.js.forEach(function(file) { %>
-      <script defer src="<%- file %>"></script>
+      <script src="<%- file %>"></script>
     <% }); %>
   </body>
 </html>

--- a/src/targets/intents/index.ejs
+++ b/src/targets/intents/index.ejs
@@ -33,6 +33,6 @@
     data-cozy="{{.CozyData}}"
   ></div>
   <% htmlPlugin.files.js.forEach(function(file) { %>
-    <script defer src="<%- file %>"></script>
+    <script src="<%- file %>"></script>
   <% }); %>
 </html>

--- a/src/targets/public/index.ejs
+++ b/src/targets/public/index.ejs
@@ -34,7 +34,7 @@
       data-cozy="{{.CozyData}}"
     ></div>
     <% htmlPlugin.files.js.forEach(function(file) { %>
-      <script defer src="<%- file %>"></script>
+      <script src="<%- file %>"></script>
     <% }); %>
   </body>
 </html>


### PR DESCRIPTION
defer was added during rsbuild migration  without being directly related to rsbuild migration and:
- it has no interest because we load an empty HTML with scripts and we are dependent to these scripts so we must wait them
- we suspect highly that defer has strange behavior on Safari causing scripts to be executed before CSS loaded leading to MUI errors