### PR TITLE
fix: Current shared drive selection

### DIFF
--- a/src/modules/navigation/components/SharedDriveListItem.tsx
+++ b/src/modules/navigation/components/SharedDriveListItem.tsx
@@ -40,7 +40,11 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
 }) => {
   const classes = useStyles()
 
-  const { driveId } = useParams()
+  const { driveId, folderId } = useParams()
+
+  const sharedDriveFolderId = sharedDrive.rules[0]?.values?.[0]
+  const isCurrentSharedDrive =
+    sharedDrive._id === driveId || sharedDriveFolderId === folderId
 
   const { link } = useSharedDriveLink(sharedDrive)
   const [isMenuAvailable, setIsMenuAvailable] = useState(false)
@@ -61,7 +65,7 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
       >
         <NavIcon
           icon={
-            driveId === sharedDrive._id
+            isCurrentSharedDrive
               ? FileTypeSharedDriveActiveIcon
               : FileTypeSharedDriveIcon
           }


### PR DESCRIPTION
[Capture vidéo du 2025-11-24 15-09-45.webm](https://github.com/user-attachments/assets/2ce5e11c-710e-4cc6-918d-df65fdf28732)

Now in the menu, the current shared can have the selection icon, even if we are owner of the current shared drive
