### PR TITLE
fix: See shared drives without recipients as shared drives

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-pouch-link": "^60.14.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.13.3",
-    "cozy-sharing": "^27.0.3",
+    "cozy-sharing": "^27.1.0",
     "cozy-stack-client": "^60.17.2",
     "cozy-ui": "^134.0.0",
     "cozy-ui-plus": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5865,10 +5865,10 @@ cozy-search@^0.13.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^27.0.3:
-  version "27.0.3"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-27.0.3.tgz#b0c93ba026756941a941ae732a1d22d960c3092c"
-  integrity sha512-OzclrPZ+io5BYPa8+pwXVdhAQYDLjN4u5FJE/m0D1xs+lhDwB0onbbdatg5Erqac4wza09WglGEFjoZA/nOjJQ==
+cozy-sharing@^27.1.0:
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-27.1.0.tgz#c4ebdfedbaa2a336c051b6ebd8edf5f4ced63639"
+  integrity sha512-eUOmt6/mA3JSnU2YR1Xf+penhnXLM3OMIrrU1ua1umi/QBbH82N8SLuNDO7LjPkwjtJ0C1gfuY23g4d9ZBtZFg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
When a shared drive has no recipient, we now see it as a shared drive when we want to add recipient to it.

Did it with an upgrade of cozy-sharing