### PR TITLE
fix: Handle double click on shared drive's content

### DIFF
--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -44,7 +44,7 @@ export const handleClick = ({
     setSelectedItems({ [file._id]: file })
   }
 
-  onInteractWithFile(file._id, event)
+  onInteractWithFile?.(file._id, event)
   setLastClickTime(currentTime)
 }
 


### PR DESCRIPTION
No more error in console when the user double clicks on shared drive content, to open a folder or to view any file content.