### PR TITLE
fix: Shared badge position in grid view

### DIFF
--- a/src/modules/filelist/File.jsx
+++ b/src/modules/filelist/File.jsx
@@ -194,7 +194,10 @@ const File = ({
             showSharedBadge={isMobile}
             componentsProps={{
               sharedBadge: {
-                className: styles['fil-content-shared']
+                className:
+                  styles[
+                    `fil-content-shared${viewType === 'grid' ? '-grid' : ''}`
+                  ]
               }
             }}
           />

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -121,7 +121,7 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
                   <SharedBadge
                     docId={file._id}
                     {...componentsProps.sharedBadge}
-                    xsmall
+                    small
                   />
                 )}
             </BadgeKonnector>
@@ -139,7 +139,7 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
                   <SharedBadge
                     docId={file._id}
                     {...componentsProps.sharedBadge}
-                    xsmall
+                    small
                   />
                 )}
             </>

--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -232,6 +232,11 @@ column-width-thumbnail-bigger = 7rem
     bottom .8rem
     right .6rem
 
+.fil-content-shared-grid
+    position    absolute
+    bottom 0
+    right 0
+
 .fil-content-shared-vz
     position    absolute
     bottom 3px


### PR DESCRIPTION
before : 
<img width="189" height="149" alt="Capture d’écran du 2025-12-02 14-21-55" src="https://github.com/user-attachments/assets/cdcb831c-9306-49f1-bdbb-f6c849556da6" />

after : 
<img width="189" height="149" alt="Capture d’écran du 2025-12-02 14-22-33" src="https://github.com/user-attachments/assets/54e410e0-b3ea-4992-8577-75a48502d457" />
