### PR TITLE
feat: Download all files with select all

### DIFF
--- a/src/modules/actions/download.jsx
+++ b/src/modules/actions/download.jsx
@@ -26,7 +26,15 @@ const makeComponent = (label, icon) => {
   return Component
 }
 
-export const download = ({ client, t, vaultClient, showAlert, driveId }) => {
+export const download = ({
+  client,
+  t,
+  vaultClient,
+  showAlert,
+  driveId,
+  isSelectAll,
+  displayedFolder
+}) => {
   const label = t('SelectionBar.download')
   const icon = DownloadIcon
 
@@ -45,9 +53,13 @@ export const download = ({ client, t, vaultClient, showAlert, driveId }) => {
       )
     },
     action: files => {
+      let selectedFiles = files
+      if (isSelectAll) {
+        selectedFiles = [displayedFolder]
+      }
       return downloadFiles(
         client,
-        files,
+        selectedFiles,
         { vaultClient, showAlert, t },
         driveId
       )

--- a/src/modules/views/Drive/DriveFolderView.jsx
+++ b/src/modules/views/Drive/DriveFolderView.jsx
@@ -173,7 +173,8 @@ const DriveFolderView = () => {
     shareFilesNative,
     selectAll: () =>
       toggleSelectAllItems(allResults.map(query => query.data).flat()),
-    isSelectAll
+    isSelectAll,
+    displayedFolder
   }
   const actions = makeActions(
     [


### PR DESCRIPTION
When select all is checked, download all files in the folder, even
when all files are not displayed.
