### PR TITLE
feat: Allow the user to rename a shared drive

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.14.1",
     "cozy-sharing": "^28.0.2",
-    "cozy-stack-client": "^60.17.2",
+    "cozy-stack-client": "^60.19.0",
     "cozy-ui": "^135.0.0",
     "cozy-ui-plus": "^4.0.0",
     "cozy-viewer": "^26.0.3",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "cozy-keys-lib": "^7.0.0",
     "cozy-logger": "^1.17.0",
     "cozy-minilog": "3.9.1",
-    "cozy-pouch-link": "^60.17.2",
+    "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.14.1",
     "cozy-sharing": "^28.0.2",

--- a/src/modules/actions/rename.jsx
+++ b/src/modules/actions/rename.jsx
@@ -6,6 +6,11 @@ import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
+import {
+  isFolderFromSharedDriveOwner,
+  isSharedDriveFolder
+} from '../shareddrives/helpers'
+
 import { startRenamingAsync } from '@/modules/drive/rename'
 
 const makeComponent = (label, icon) => {
@@ -32,7 +37,11 @@ export const rename = ({ t, hasWriteAccess, dispatch }) => {
     name: 'rename',
     label,
     icon,
-    displayCondition: selection => hasWriteAccess && selection.length === 1,
+    displayCondition: selection =>
+      selection.length === 1 &&
+      (hasWriteAccess ||
+        (isSharedDriveFolder(selection[0]) &&
+          isFolderFromSharedDriveOwner(selection[0]))),
     action: files => dispatch(startRenamingAsync(files[0])),
     Component: makeComponent(label, icon)
   }

--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
@@ -38,7 +38,11 @@ export const useBreadcrumbPath = ({
   }
 
   useEffect(() => {
-    if (!folderAttributes.id || !folderAttributes.name) return
+    if (!folderAttributes.id || !folderAttributes.name) {
+      // Optionally set loading state or clear paths
+      setPaths([])
+      return
+    }
 
     const hasAccessToSharedDocument = id => {
       if (!sharedDocumentIds) return true
@@ -64,7 +68,7 @@ export const useBreadcrumbPath = ({
 
     const shouldAddRootPath = () => {
       return (
-        rootBreadcrumbPath.name !== 'Public' &&
+        rootBreadcrumbPath?.name !== 'Public' &&
         returnedPaths[0]?.id !== rootBreadcrumbPath.id
       )
     }

--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
@@ -55,7 +55,9 @@ export const useBreadcrumbPath = ({
     ]
 
     const shouldContinueLoop = id => {
-      return !!id && id !== rootBreadcrumbPath.id && id !== SHARED_DRIVES_DIR_ID
+      return (
+        !!id && id !== rootBreadcrumbPath?.id && id !== SHARED_DRIVES_DIR_ID
+      )
     }
 
     const processFolder = async id => {

--- a/src/modules/breadcrumb/utils/fetchFolder.js
+++ b/src/modules/breadcrumb/utils/fetchFolder.js
@@ -1,3 +1,5 @@
+import { useQuery } from 'cozy-client'
+
 import {
   buildFileOrFolderByIdQuery,
   buildSharedDriveFolderQuery
@@ -12,5 +14,22 @@ export const fetchFolder = async ({ client, folderId, driveId }) => {
     definition: definition(),
     options
   })
+  return driveId ? folderQueryResults.data?.[0] : folderQueryResults.data
+}
+
+/**
+ * Hook to fetch a folder from cozy stack
+ *
+ * @param {Object} params - The parameters for the function.
+ * @param {string} params.folderId - The ID of the folder to fetch.
+ * @param {string} [params.driveId] - The ID of the shared drive to fetch the folder from.
+ * @returns {import('cozy-client/types/types').IOCozyFolder} The folder data.
+ */
+export const useFolder = ({ folderId, driveId }) => {
+  const folderQuery = driveId
+    ? buildSharedDriveFolderQuery({ driveId, folderId })
+    : buildFileOrFolderByIdQuery(folderId)
+  const { options, definition } = folderQuery
+  const folderQueryResults = useQuery(definition, options)
   return driveId ? folderQueryResults.data?.[0] : folderQueryResults.data
 }

--- a/src/modules/drive/RenameInput.jsx
+++ b/src/modules/drive/RenameInput.jsx
@@ -14,11 +14,14 @@ import FilenameInput from '@/modules/filelist/FilenameInput'
 
 // If we set the _rev then CozyClient tries to update. Else
 // it tries to create
-const updateFileNameQuery = async (client, file, newName) => {
+export const updateFileNameQuery = async (client, file, newName) => {
   if (isFolderFromSharedDriveOwner(file)) {
     const referencedBy = file.relationships?.referenced_by?.data?.[0]
     if (!referencedBy?.id) {
       throw new Error('Shared drive folder is missing required relationships')
+    }
+    if (!file.id) {
+      throw new Error('Shared drive folder is missing required id')
     }
     const sharing = {
       _id: referencedBy.id,

--- a/src/modules/drive/RenameInput.jsx
+++ b/src/modules/drive/RenameInput.jsx
@@ -7,6 +7,7 @@ import useBrowserOffline from 'cozy-ui/transpiled/react/hooks/useBrowserOffline'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 
 import { abortRenaming } from './rename'
+import { isFolderFromSharedDriveOwner } from '../shareddrives/helpers'
 
 import { CozyFile } from '@/models'
 import FilenameInput from '@/modules/filelist/FilenameInput'
@@ -14,6 +15,15 @@ import FilenameInput from '@/modules/filelist/FilenameInput'
 // If we set the _rev then CozyClient tries to update. Else
 // it tries to create
 const updateFileNameQuery = async (client, file, newName) => {
+  if (isFolderFromSharedDriveOwner(file)) {
+    const sharing = {
+      _id: file.relationships.referenced_by.data[0].id,
+      rules: [{ values: [file.id] }]
+    }
+    return client
+      .collection('io.cozy.sharings')
+      .renameSharedDrive(sharing, newName)
+  }
   return client.collection('io.cozy.files', { driveId: file.driveId }).update({
     ...file,
     name: newName,

--- a/src/modules/drive/RenameInput.jsx
+++ b/src/modules/drive/RenameInput.jsx
@@ -16,8 +16,12 @@ import FilenameInput from '@/modules/filelist/FilenameInput'
 // it tries to create
 const updateFileNameQuery = async (client, file, newName) => {
   if (isFolderFromSharedDriveOwner(file)) {
+    const referencedBy = file.relationships?.referenced_by?.data?.[0]
+    if (!referencedBy?.id) {
+      throw new Error('Shared drive folder is missing required relationships')
+    }
     const sharing = {
-      _id: file.relationships.referenced_by.data[0].id,
+      _id: referencedBy.id,
       rules: [{ values: [file.id] }]
     }
     return client

--- a/yarn.lock
+++ b/yarn.lock
@@ -7062,7 +7062,7 @@ es6-object-assign@^1.1.0:
 es6-promise-pool@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
-  integrity sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs=
+  integrity sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==
 
 es6-promise@^4.2.8:
   version "4.2.8"
@@ -11160,7 +11160,7 @@ oauth-sign@~0.9.0:
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+  integrity sha512-jHP15vXVGeVh1HuaA2wY6lxk+whK/x4KBG88VXeRma7CCun7iGD5qPc4eYykQ9sdQvg8jkwFKsSxHln2ybW3xQ==
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -12700,7 +12700,7 @@ react-test-renderer@16.14.0:
 react-themeable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
-  integrity sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=
+  integrity sha512-kl5tQ8K+r9IdQXZd8WLa+xxYN04lLnJXRVhHfdgwsUJr/SlKJxIejoc9z9obEkx1mdqbTw1ry43fxEUwyD9u7w==
   dependencies:
     object-assign "^3.0.0"
 
@@ -13420,7 +13420,7 @@ schema-utils@^3.0.0:
 section-iterator@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
-  integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
+  integrity sha512-xvTNwcbeDayXotnV32zLb3duQsP+4XosHpb/F+tu6VzEZFmIjzPdNk6/O+QOOx5XTh08KL2ufdXeCO33p380pQ==
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5543,33 +5543,6 @@ cozy-client@^45.14.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^60.17.2:
-  version "60.17.2"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.17.2.tgz#49a8f6774d1cbe0ae903abb354ff566ae3d18ecd"
-  integrity sha512-DyY1QylcFhKjc56TuPtxCha4qYSWZYklVOnIZXE9y+T69dOUqrPYhit1zwEyLtIDUsdvFCTyEAvwzjwCNNVTlg==
-  dependencies:
-    "@cozy/minilog" "1.0.0"
-    "@fastify/deepmerge" "^2.0.2"
-    "@types/jest" "^26.0.20"
-    "@types/lodash" "^4.14.170"
-    btoa "^1.2.1"
-    cozy-stack-client "^60.17.2"
-    date-fns "^2.30.0"
-    fast-deep-equal "^3.1.3"
-    json-stable-stringify "^1.0.1"
-    lodash "^4.17.13"
-    microee "^0.0.6"
-    node-fetch "^2.6.1"
-    node-polyglot "2.4.2"
-    open "7.4.2"
-    prop-types "^15.6.2"
-    react-redux "^7.2.0"
-    redux "3 || 4"
-    redux-thunk "^2.3.0"
-    server-destroy "^1.0.1"
-    sift "^6.0.0"
-    url-search-params-polyfill "^8.0.0"
-
 cozy-client@^60.20.0:
   version "60.20.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.20.0.tgz#ac8363bdf438fb36c1fccd78b04803bc214629ad"
@@ -5838,12 +5811,12 @@ cozy-minilog@^3.10.0:
   dependencies:
     microee "0.0.6"
 
-cozy-pouch-link@^60.17.2:
-  version "60.17.2"
-  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-60.17.2.tgz#6293002cef52a7bc10f571a5be8652520ea78430"
-  integrity sha512-0EsMcYWK/GvhKOQeERRwNTQnYiwvhM/zInzsNmiUQLtQGiSs5InYoOgmmB6gaz2HI3LQrRQf/s8RZbcdWEB46A==
+cozy-pouch-link@^60.19.0:
+  version "60.20.0"
+  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-60.20.0.tgz#4990276bc619992f81ab7ff497bf5a1cb0553d45"
+  integrity sha512-svS3SAxisugqKfcmaTVDJzshjCZWu+Bb/QF6u2JPiueEyWuQG/WVrkVd5HIpxA3B6AUnh7rUQGQZxwURjDUFPQ==
   dependencies:
-    cozy-client "^60.17.2"
+    cozy-client "^60.20.0"
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"
 
@@ -5884,15 +5857,6 @@ cozy-stack-client@^45.13.0:
   version "45.13.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-45.13.0.tgz#394b21a153b752be99ac6c79d073159fd024a4f4"
   integrity sha512-ruigDMH6XB1Pxa+e3doAMjXihgKSdNZpNPlEcpd7l8MfHazUaHVs/D8Kyop1n+VGM/4va2DU1c1nE7ainT7+jw==
-  dependencies:
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
-
-cozy-stack-client@^60.17.2:
-  version "60.17.2"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-60.17.2.tgz#dc89b303c43c5f2131625540b19313965c71f183"
-  integrity sha512-o67ylk1M4A+nrLywx0jjRHCr9utFGFYj+aAFC2W0gApuaszj561jKzPPTYZMjmoJVjFLY4F/brmOIxIwe181/A==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
- Also added realtime on the folder name in breadcrumb to let
the user see the result of the rename.
- It is now also possible to rename a shared drive from the sharings section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support renaming folders owned by shared drives via a dedicated sharing rename flow.

* **Improvements**
  * Rename action visibility refined to respect selection and access rules, including shared‑drive owner cases.
  * Breadcrumb construction and traversal made more robust with clearer initialization, loop control, root handling, and error messaging.

* **Tests**
  * Updated and added tests covering breadcrumb traversal and shared‑drive rename scenarios.

* **Chores**
  * Updated dependencies: cozy-pouch-link, cozy-stack-client.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->