### PR TITLE
fix: Add ellipsis to shared drive menu item

### DIFF
--- a/src/modules/navigation/components/SharedDriveListItem.tsx
+++ b/src/modules/navigation/components/SharedDriveListItem.tsx
@@ -20,6 +20,9 @@ const useStyles = makeStyles({
     flex: 1,
     minWidth: 0
   },
+  menuItem: {
+    minWidth: 0
+  },
   menuContainer: {
     display: 'flex',
     alignItems: 'center',
@@ -60,7 +63,11 @@ const SharedDriveListItem: FC<SharedDriveListItemProps> = ({
     >
       <FileLink
         link={link}
-        className={cx(NavLink.className, isMenuAvailable && classes.withMenu)}
+        className={cx(
+          NavLink.className,
+          isMenuAvailable && classes.withMenu,
+          classes.menuItem
+        )}
         onClick={(): void => setLastClicked(undefined)}
       >
         <NavIcon


### PR DESCRIPTION
Before:
<img width="246" height="145" alt="image" src="https://github.com/user-attachments/assets/fd0380d1-ad58-478a-bb2e-e6eb537d7306" />

After:
<img width="246" height="145" alt="image" src="https://github.com/user-attachments/assets/e7818222-6f4f-4a69-8212-0477ca27564c" />
