### PR TITLE
feat: Display view switcher for recent files

### DIFF
--- a/src/modules/filelist/FileListHeaderMobile.jsx
+++ b/src/modules/filelist/FileListHeaderMobile.jsx
@@ -36,24 +36,27 @@ const FileListHeaderMobile = ({
     [setIsShowingSortMenu]
   )
 
-  if (!canSort) return null
-
   return (
     <TableHead className={styles['fil-content-mobile-head']}>
       <TableRow className={styles['fil-content-row-head']}>
-        <TableHeader
-          onClick={showSortMenu}
-          className={cx(
-            styles['fil-content-mobile-header'],
-            styles['fil-content-header--capitalize'],
-            {
-              [styles['fil-content-header-sortasc']]: sort.order === 'asc',
-              [styles['fil-content-header-sortdesc']]: sort.order === 'desc'
-            }
-          )}
-        >
-          {t(`table.mobile.head_${sort.attribute}_${sort.order}`)}
-        </TableHeader>
+        {canSort ? (
+          <TableHeader
+            onClick={showSortMenu}
+            className={cx(
+              styles['fil-content-mobile-header'],
+              styles['fil-content-header--capitalize'],
+              {
+                [styles['fil-content-header-sortasc']]: sort.order === 'asc',
+                [styles['fil-content-header-sortdesc']]: sort.order === 'desc'
+              }
+            )}
+          >
+            {t(`table.mobile.head_${sort.attribute}_${sort.order}`)}
+          </TableHeader>
+        ) : (
+          <div className="u-flex-auto" /> // to keep the viewType switch to the right side
+        )}
+
         {isShowingSortMenu && (
           <MobileSortMenu
             t={t}

--- a/src/modules/views/Folder/hooks/useFileSorting.js
+++ b/src/modules/views/Folder/hooks/useFileSorting.js
@@ -1,0 +1,65 @@
+import { useMemo, useCallback } from 'react'
+
+import {
+  stableSort,
+  getComparator
+} from 'cozy-ui/transpiled/react/Table/Virtualized/helpers'
+
+import { secondarySort } from '../helpers'
+
+import { useFolderSort } from '@/hooks'
+
+/**
+ * Custom hook for handling file sorting logic
+ * @param {string} currentFolderId - The current folder ID
+ * @param {Array} queryResults - Query results containing files
+ * @param {Object} orderProps - External order properties (optional)
+ * @returns {Object} Sorting state and functions
+ */
+export const useFileSorting = (currentFolderId, queryResults, orderProps) => {
+  // Get internal sorting state from existing hook
+  const [internalSortOrder, internalSetSortOrder, internalIsSettingsLoaded] =
+    useFolderSort(currentFolderId)
+
+  // Merge internal and external sort properties
+  const sortOrder = orderProps?.sortOrder ?? internalSortOrder
+  const setSortOrder = orderProps?.setOrder ?? internalSetSortOrder
+  const isSettingsLoaded =
+    orderProps?.isSettingsLoaded ?? internalIsSettingsLoaded
+
+  // Extract all files from query results
+  const allFiles = useMemo(() => {
+    const files = []
+    queryResults.forEach(query => {
+      if (query.data && query.data.length > 0) {
+        files.push(...query.data)
+      }
+    })
+    return files
+  }, [queryResults])
+
+  // Sort files based on current sort order
+  const sortedFiles = useMemo(() => {
+    const { order, attribute: orderBy } = sortOrder
+    if (!order || !orderBy) {
+      return secondarySort(allFiles)
+    }
+    const sortedData = stableSort(allFiles, getComparator(order, orderBy))
+    return secondarySort(sortedData)
+  }, [allFiles, sortOrder])
+
+  // Create sort change handler
+  const changeSortOrder = useCallback(
+    (_, attribute, order) => setSortOrder({ attribute, order }),
+    [setSortOrder]
+  )
+
+  return {
+    sortOrder,
+    setSortOrder,
+    isSettingsLoaded,
+    allFiles,
+    sortedFiles,
+    changeSortOrder
+  }
+}

--- a/src/modules/views/Folder/hooks/useFileSorting.spec.js
+++ b/src/modules/views/Folder/hooks/useFileSorting.spec.js
@@ -1,0 +1,176 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useFileSorting } from './useFileSorting'
+
+// Mock des dépendances
+jest.mock('@/hooks', () => ({
+  useFolderSort: jest.fn(() => [
+    { order: 'asc', attribute: 'name' },
+    jest.fn(),
+    true
+  ])
+}))
+
+jest.mock('cozy-ui/transpiled/react/Table/Virtualized/helpers', () => ({
+  stableSort: jest.fn((data, comparator) => [...data].sort(comparator)),
+  getComparator: jest.fn((order, orderBy) => (a, b) => {
+    if (order === 'asc') {
+      return a[orderBy]?.localeCompare(b[orderBy])
+    }
+    return b[orderBy]?.localeCompare(a[orderBy])
+  })
+}))
+
+describe('useFileSorting', () => {
+  const mockQueryResults = [
+    {
+      data: [
+        {
+          _id: '1',
+          name: 'file-b.txt',
+          type: 'file',
+          updated_at: '2023-01-01T10:00:00Z'
+        },
+        {
+          _id: '2',
+          name: 'file-a.txt',
+          type: 'file',
+          updated_at: '2023-01-01T11:00:00Z'
+        },
+        {
+          _id: '3',
+          name: 'folder-c',
+          type: 'directory',
+          updated_at: '2023-01-01T12:00:00Z'
+        }
+      ]
+    }
+  ]
+
+  const mockOrderProps = {
+    sortOrder: { order: 'desc', attribute: 'updated_at' },
+    setOrder: jest.fn(),
+    isSettingsLoaded: true
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should extract all files from query results', () => {
+    const { result } = renderHook(() =>
+      useFileSorting('folder-1', mockQueryResults, {})
+    )
+
+    expect(result.current.allFiles).toHaveLength(3)
+    expect(result.current.allFiles[0]._id).toBe('1')
+  })
+
+  it('should use internal sort order when no orderProps provided', () => {
+    const { result } = renderHook(() =>
+      useFileSorting('folder-1', mockQueryResults, {})
+    )
+
+    expect(result.current.sortOrder).toEqual({
+      order: 'asc',
+      attribute: 'name'
+    })
+  })
+
+  it('should use external sort order when orderProps provided', () => {
+    const { result } = renderHook(() =>
+      useFileSorting('folder-1', mockQueryResults, mockOrderProps)
+    )
+
+    expect(result.current.sortOrder).toEqual({
+      order: 'desc',
+      attribute: 'updated_at'
+    })
+  })
+
+  it('should apply secondary sort (directories before files)', () => {
+    const { result } = renderHook(() =>
+      useFileSorting(
+        'folder-1',
+        [
+          {
+            data: [
+              { _id: '1', name: 'file.txt', type: 'file' },
+              { _id: '2', name: 'folder', type: 'directory' }
+            ]
+          }
+        ],
+        {}
+      )
+    )
+
+    // Secondary sort should put directories before files
+    expect(result.current.sortedFiles[0].type).toBe('directory')
+    expect(result.current.sortedFiles[1].type).toBe('file')
+  })
+
+  it('should apply both primary and secondary sort', () => {
+    const { result } = renderHook(() =>
+      useFileSorting('folder-1', mockQueryResults, mockOrderProps)
+    )
+
+    // Should be sorted by updated_at in descending order (most recent first), then by type
+    expect(result.current.sortedFiles).toHaveLength(3)
+
+    // Verify the actual sort ordering
+    const sortedFiles = result.current.sortedFiles
+
+    // Expected order: updated_at descending (folder-c:12:00, file-a.txt:11:00, file-b.txt:10:00)
+    // Secondary sort: directories before files (folder-c should come before files)
+    expect(sortedFiles[0].name).toBe('folder-c')
+    expect(sortedFiles[0].type).toBe('directory')
+
+    expect(sortedFiles[1].name).toBe('file-a.txt')
+    expect(sortedFiles[1].type).toBe('file')
+
+    expect(sortedFiles[2].name).toBe('file-b.txt')
+    expect(sortedFiles[2].type).toBe('file')
+
+    // Alternative verification: map filenames and types
+    const fileInfo = sortedFiles.map(file => ({
+      name: file.name,
+      type: file.type
+    }))
+    expect(fileInfo).toEqual([
+      { name: 'folder-c', type: 'directory' },
+      { name: 'file-a.txt', type: 'file' },
+      { name: 'file-b.txt', type: 'file' }
+    ])
+  })
+
+  it('should create changeSortOrder callback', () => {
+    const { result } = renderHook(() =>
+      useFileSorting('folder-1', mockQueryResults, mockOrderProps)
+    )
+
+    result.current.changeSortOrder(null, 'size', 'asc')
+    expect(mockOrderProps.setOrder).toHaveBeenCalledWith({
+      attribute: 'size',
+      order: 'asc'
+    })
+  })
+
+  it('should handle empty query results', () => {
+    const { result } = renderHook(() => useFileSorting('folder-1', [], {}))
+
+    expect(result.current.allFiles).toHaveLength(0)
+    expect(result.current.sortedFiles).toHaveLength(0)
+  })
+
+  it('should handle query results with empty data arrays', () => {
+    const { result } = renderHook(() =>
+      useFileSorting(
+        'folder-1',
+        [{ data: [] }, { data: null }, { data: undefined }],
+        {}
+      )
+    )
+
+    expect(result.current.allFiles).toHaveLength(0)
+  })
+})

--- a/src/modules/views/Recent/index.jsx
+++ b/src/modules/views/Recent/index.jsx
@@ -162,7 +162,6 @@ export const RecentView = () => {
           <FolderViewBody
             actions={actions}
             queryResults={[recentsResult]}
-            canSort={false}
             withFilePath={true}
             extraColumns={extraColumns}
           />


### PR DESCRIPTION
And also allow to hide sorter when canSort is not true.

<img width="337" height="584" alt="image" src="https://github.com/user-attachments/assets/d405fffd-4f5a-4999-8191-8a005c8e3879" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile file list header layout corrected to preserve right-side alignment while properly showing sort controls.

* **New Features**
  * Centralized file-sorting applied across Folder and Recent views for consistent, stable sorting and selection behavior.

* **Tests**
  * Added comprehensive tests covering sorting logic, default and external sort orders, secondary sorting, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->