### PR TITLE
fix: Mobile sharing view for shared drive

### DIFF
--- a/src/modules/filelist/File.jsx
+++ b/src/modules/filelist/File.jsx
@@ -133,7 +133,6 @@ const File = ({
   let canInteractWithFile =
     attributes._id &&
     attributes._id !== 'io.cozy.files.shared-drives-dir' &&
-    attributes.dir_id !== 'io.cozy.files.shared-drives-dir' &&
     !attributes._id.endsWith('.trash-dir')
   if (typeof canInteractWith === 'function') {
     canInteractWithFile &&= canInteractWith(attributes)

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 import { isReferencedBy, models } from 'cozy-client'
@@ -75,11 +76,20 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
     isSharedDriveFolder(file)
   ) {
     return (
-      <Icon
-        className="u-mr-half"
-        icon={FileTypeSharedDriveIcon}
-        size={size ?? 32}
-      />
+      <>
+        <Icon icon={FileTypeSharedDriveIcon} size={size ?? 32} />
+        <div
+          className={classNames('u-pos-absolute', {
+            'u-bottom-xs u-right-xs': viewType === 'list',
+            'u-bottom-0 u-right-0': viewType === 'grid'
+          })}
+        >
+          <SharingOwnerAvatar
+            docId={file._id}
+            size={viewType === 'list' ? 'xs' : 's'}
+          />
+        </div>
+      </>
     )
   }
 

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -256,7 +256,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
               <FolderViewBody
                 actions={actions}
                 queryResults={[filteredResult]}
-                canSort={false}
+                canSort={true}
                 withFilePath={true}
                 extraColumns={extraColumns}
                 orderProps={{


### PR DESCRIPTION
https://www.notion.so/linagora/UI-UX-shared-drive-mobile-bug-2bd62718bad180b18251eb6268fcf262

- Display sort / change view header in sharings on mobile
<img width="440" height="132" alt="image" src="https://github.com/user-attachments/assets/34c144f9-fa1d-4bc1-9a99-33d512cdbf45" />

- Display context menu for shared drives in sharings on mobile
<img width="414" height="308" alt="image" src="https://github.com/user-attachments/assets/c48aed91-3527-4e4b-8b08-baa4f19f5dcc" />

- Display avatar of shared drive owner for shared drive on mobile

list view: 
<img width="334" height="392" alt="image" src="https://github.com/user-attachments/assets/d1a2a857-5394-47df-9030-92fdf0c00fa7" />

grid view:
<img width="337" height="584" alt="image" src="https://github.com/user-attachments/assets/c86cb48c-5781-4629-830f-292a54836b71" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored interaction for items in shared drives that were previously disabled.

* **New Features**
  * Added owner-avatar overlay to shared-drive folder thumbnails with adaptive positioning and sizing by view type.
  * Enabled sorting in the Sharings listing (non-virtualized view).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->