### PR TITLE
feat: Hide shared drive owner icon in desktop / grid mode

### DIFF
--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -13,6 +13,7 @@ import LinkIcon from 'cozy-ui/transpiled/react/Icons/Link'
 import TrashDuotoneIcon from 'cozy-ui/transpiled/react/Icons/TrashDuotone'
 import InfosBadge from 'cozy-ui/transpiled/react/InfosBadge'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import styles from '@/styles/filelist.styl'
 
@@ -51,6 +52,7 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
   }
 }) => {
   const { viewType } = useViewSwitcherContext()
+  const { isMobile } = useBreakpoints()
 
   if (isNextcloudFile(file)) {
     return <FileIconMime file={file} size={size} />
@@ -84,10 +86,12 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
             'u-bottom-0 u-right-0': viewType === 'grid'
           })}
         >
-          <SharingOwnerAvatar
-            docId={file._id}
-            size={viewType === 'list' ? 'xs' : 's'}
-          />
+          {isMobile && (
+            <SharingOwnerAvatar
+              docId={file._id}
+              size={viewType === 'list' ? 'xs' : 's'}
+            />
+          )}
         </div>
       </>
     )


### PR DESCRIPTION
Since the owner is already displayed in another way in this case:

Before:
<img width="142" height="179" alt="image" src="https://github.com/user-attachments/assets/299f0b1e-8c86-4b63-b407-392ca248434f" />

After:
<img width="142" height="179" alt="image" src="https://github.com/user-attachments/assets/fcfcba8e-f493-47c1-9577-62d45c348009" />

https://www.notion.so/linagora/UI-UX-shared-drive-mobile-bug-2bd62718bad180b18251eb6268fcf262




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File list component now implements responsive behavior, displaying sharing owner information exclusively on mobile devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->