### PR TITLE
feat: Change leave shared drive button icon and label on mobile

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,7 +41,7 @@
   },
   "toolbar": {
     "menu_manage_access": "Manage access",
-    "menu_leave_shared_drive": "Leave shared drive",
+    "menu_leave_shared_drive": "Leave drive",
     "menu_upload": "Upload files",
     "item_more": "More",
     "menu_new_folder": "Folder",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -41,7 +41,7 @@
   },
   "toolbar": {
     "menu_manage_access": "Gérer les accès",
-    "menu_leave_shared_drive": "Quitter le drive partagé",
+    "menu_leave_shared_drive": "Sortir drive",
     "menu_upload": "Importer des fichiers",
     "item_more": "Plus",
     "menu_new_folder": "Dossier",

--- a/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
+++ b/src/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem.jsx
@@ -5,7 +5,7 @@ import { useI18n } from 'twake-i18n'
 import { useClient } from 'cozy-client'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import LogoutIcon from 'cozy-ui/transpiled/react/Icons/Logout'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
@@ -33,7 +33,7 @@ const LeaveSharedDriveButtonItem = ({ files }) => {
   return (
     <ActionsMenuItem onClick={handleClick}>
       <ListItemIcon>
-        <Icon icon={TrashIcon} className="u-error" />
+        <Icon icon={LogoutIcon} className="u-error" />
       </ListItemIcon>
       <ListItemText primary={t('toolbar.menu_leave_shared_drive')} />
     </ActionsMenuItem>

--- a/src/modules/shareddrives/components/actions/leaveSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/leaveSharedDrive.js
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import LogoutIcon from 'cozy-ui/transpiled/react/Icons/Logout'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
@@ -10,7 +10,7 @@ import { isFolderFromSharedDriveRecipient } from '@/modules/shareddrives/helpers
 
 export const leaveSharedDrive = ({ sharedDrive, client, showAlert, t }) => {
   const label = t('toolbar.menu_leave_shared_drive')
-  const icon = TrashIcon
+  const icon = LogoutIcon
 
   return {
     name: 'leaveSharedDrive',


### PR DESCRIPTION
https://www.notion.so/linagora/UI-UX-shared-drive-mobile-bug-2bd62718bad180b18251eb6268fcf262

<img width="517" height="474" alt="image" src="https://github.com/user-attachments/assets/5edda9e2-50a5-4028-bcb4-36db4ee85757" />

And yes "Sortir drive" is not a very good label, but that is the only one we could find to fit in the menu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated text for the leave drive menu item in English and French.

* **UI Updates**
  * Updated the icon used for the leave drive action throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->