### PR TITLE
feat: Show share button in mobile

### DIFF
--- a/src/modules/drive/Toolbar/share/ShareButton.jsx
+++ b/src/modules/drive/Toolbar/share/ShareButton.jsx
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -16,12 +15,14 @@ const ShareButtonWithProps = ({ isDisabled, className, useShortLabel }) => {
     navigate(getPathToShareDisplayedFolder(pathname))
   }
 
+  if (!displayedFolder) return null
+
   return (
     <ShareButton
       docId={displayedFolder.id}
       disabled={isDisabled}
       useShortLabel={useShortLabel}
-      className={cx('u-hide--mob', className)}
+      className={className}
       onClick={() => share(displayedFolder)}
     />
   )

--- a/src/modules/filelist/FileListHeaderMobile.jsx
+++ b/src/modules/filelist/FileListHeaderMobile.jsx
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import React, { useState, useCallback } from 'react'
 import { useI18n } from 'twake-i18n'
 
+import { useSharingContext } from 'cozy-sharing'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ListIcon from 'cozy-ui/transpiled/react/Icons/List'
@@ -13,11 +14,15 @@ import {
 } from 'cozy-ui/transpiled/react/deprecated/Table'
 
 import MobileSortMenu from './MobileSortMenu'
+import ShareButton from '../drive/Toolbar/share/ShareButton'
 
 import styles from '@/styles/filelist.styl'
 
+import { ROOT_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
+import { useCurrentFolderId } from '@/hooks'
+import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+
 const FileListHeaderMobile = ({
-  folderId,
   canSort,
   sort,
   onFolderSort,
@@ -26,6 +31,16 @@ const FileListHeaderMobile = ({
 }) => {
   const { t } = useI18n()
   const [isShowingSortMenu, setIsShowingSortMenu] = useState(false)
+  const { isSelectionBarVisible } = useSelectionContext()
+  const { allLoaded } = useSharingContext()
+
+  const folderId = useCurrentFolderId()
+  const showShareButton = Boolean(
+    folderId && folderId !== ROOT_DIR_ID && folderId !== TRASH_DIR_ID
+  )
+
+  const isDisabled = isSelectionBarVisible
+  const isSharingDisabled = isDisabled || !allLoaded
 
   const showSortMenu = useCallback(
     () => setIsShowingSortMenu(true),
@@ -64,6 +79,16 @@ const FileListHeaderMobile = ({
             onClose={hideSortMenu}
             onSort={(attr, order) => onFolderSort(folderId, attr, order)}
           />
+        )}
+        {showShareButton && (
+          <TableHeader
+            className={cx(
+              styles['fil-content-mobile-header'],
+              styles['fil-content-header--capitalize']
+            )}
+          >
+            <ShareButton isDisabled={isSharingDisabled} useShortLabel={true} />
+          </TableHeader>
         )}
         <TableHeader
           className={cx(


### PR DESCRIPTION
<img width="352" height="224" alt="image" src="https://github.com/user-attachments/assets/4fbb388e-703e-4bf7-954e-59d10e336a38" />

<img width="352" height="224" alt="image" src="https://github.com/user-attachments/assets/114363bc-74e3-42a6-982c-84061badc863" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated share functionality into the mobile file list header for easier access.

* **Improvements**
  * Optimized share button behavior to disable appropriately when no items are selected or when data is still loading, improving user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->