### PR TITLE
fix: Upgrade cozy-sharing to 28.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.14.1",
-    "cozy-sharing": "^28.0.2",
+    "cozy-sharing": "^28.1.0",
     "cozy-stack-client": "^60.19.0",
     "cozy-ui": "^135.0.0",
     "cozy-ui-plus": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,10 +5838,10 @@ cozy-search@^0.14.1:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.0.2.tgz#8a51d3159cfdd399c9411d4be1ddc55f2ee46665"
-  integrity sha512-knYzCSDb//zNmiy3nvdrEiVJ/dhmmvNuIb324LSiKn6LZ8YaBgt3kqQQQcbH6K0UAHisUcfk/21Oinoek9VFFA==
+cozy-sharing@^28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.1.0.tgz#a8b4fa55d3d9d8b6f53bb1542d4d6c1a1413a958"
+  integrity sha512-lj4CRGVRBxKAa4AJSDMrxAel5yiYJ3/3KgvegoLdX0kc+StvCxJfkkZJUoAN4VL6m8jyf2cDo+CGtdXayPdIvA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
To have only one primary action in shared drive edit modale
https://github.com/linagora/cozy-libs/pull/2893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared library dependency to the latest minor version for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->