### PR TITLE
fix: Change text color of delete and leave shared drive action

### DIFF
--- a/src/modules/shareddrives/components/actions/deleteSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/deleteSharedDrive.js
@@ -76,7 +76,7 @@ export const deleteSharedDrive = ({
           <ListItemIcon>
             <Icon icon={icon} className="u-error" />
           </ListItemIcon>
-          <ListItemText primary={label} />
+          <ListItemText primary={label} className="u-error" />
         </ActionsMenuItem>
       )
     })

--- a/src/modules/shareddrives/components/actions/leaveSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/leaveSharedDrive.js
@@ -42,7 +42,7 @@ export const leaveSharedDrive = ({ sharedDrive, client, showAlert, t }) => {
           <ListItemIcon>
             <Icon icon={icon} className="u-error" />
           </ListItemIcon>
-          <ListItemText primary={label} />
+          <ListItemText primary={label} className="u-error" />
         </ActionsMenuItem>
       )
     })


### PR DESCRIPTION
<img width="321" height="267" alt="image" src="https://github.com/user-attachments/assets/4fa57086-286c-45a1-9502-e55cc61483f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual distinction for delete and leave shared drive actions by applying error-state styling to menu items, making their destructive nature more apparent to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->