### PR TITLE
fix: Allow to update properties of files in shared folders

### DIFF
--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -13,6 +13,7 @@ import Viewer, {
   SharingButton
 } from 'cozy-viewer'
 
+import { ensureFileHasPath } from '@/components/FilesRealTimeQueries'
 import { FilesViewerLoading } from '@/components/FilesViewerLoading'
 import RightClickFileMenu from '@/components/RightClick/RightClickFileMenu'
 import { useCurrentFileId } from '@/hooks'
@@ -91,7 +92,8 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
         const { data } = await client.query(
           Q('io.cozy.files').getById(fileId).sharingById(driveId)
         )
-        isMounted && setCurrentFile(data)
+        const fileWithPath = await ensureFileHasPath(data, client)
+        isMounted && setCurrentFile(fileWithPath)
       } catch (e) {
         logger.warn("can't find the file")
         handleOnClose()


### PR DESCRIPTION
Files returned by sharingById from cozy-client don't have a path. This is a problem for the viewer as it uses the path to check if the file is writeable. This commit adds a call to ensureFileHasPath calculates the path and returns a file with a path.

https://www.notion.so/linagora/Public-link-sharing-bug-delete-2c762718bad180bb91d4c6b0d7a43283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file retrieval to ensure proper path resolution when loading files by ID, preventing potential display issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->