### PR TITLE
feat: Display full breadcrumb in public view

### DIFF
--- a/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
+++ b/src/modules/views/Folder/OldFolderViewBreadcrumb.jsx
@@ -1,20 +1,50 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { useQuery } from 'cozy-client'
+import { useClient } from 'cozy-client'
 
+import logger from '@/lib/logger'
 import { MobileAwareBreadcrumb as Breadcrumb } from '@/modules/breadcrumb/components/MobileAwareBreadcrumb'
-import { buildFileOrFolderByIdQuery } from '@/queries'
 
-const FolderViewBreadcrumb = ({ currentFolderId, getBreadcrumbPath }) => {
+const FolderViewBreadcrumb = ({
+  displayedFolder,
+  sharedDocumentId,
+  getBreadcrumbPath
+}) => {
   const navigate = useNavigate()
-  const currentFolderQuery = buildFileOrFolderByIdQuery(currentFolderId)
-  const currentFolderQueryResults = useQuery(
-    currentFolderQuery.definition,
-    currentFolderQuery.options
-  )
-  const currentFolder = currentFolderQueryResults.data
-  const path = currentFolder ? getBreadcrumbPath(currentFolder) : []
+  const client = useClient()
+  const [path, setPath] = useState(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    setPath(null)
+    if (!displayedFolder || !sharedDocumentId) return
+
+    const asyncGetPaths = async () => {
+      try {
+        const paths = await getBreadcrumbPath({
+          client,
+          displayedFolder,
+          sharedDocumentId
+        })
+        if (isMounted) {
+          setPath(paths)
+        }
+      } catch (error) {
+        logger.error(`Error while fetching breadcrumb path: ${error}`)
+        if (isMounted) {
+          setPath(null)
+        }
+      }
+    }
+
+    asyncGetPaths()
+
+    return () => {
+      isMounted = false
+    }
+  }, [displayedFolder, sharedDocumentId, client, getBreadcrumbPath])
 
   const onBreadcrumbClick = useCallback(
     ({ id }) => {
@@ -25,7 +55,7 @@ const FolderViewBreadcrumb = ({ currentFolderId, getBreadcrumbPath }) => {
     [navigate]
   )
 
-  return currentFolder ? (
+  return path ? (
     <Breadcrumb
       path={path}
       onBreadcrumbClick={onBreadcrumbClick}

--- a/src/targets/public/components/AppRouter.jsx
+++ b/src/targets/public/components/AppRouter.jsx
@@ -79,14 +79,20 @@ const AppRouter = ({
               path="/files/:folderId"
               element={<Navigate to="/folder/:folderId" />}
             />
-            <Route path="folder" element={<PublicFolderView />}>
+            <Route
+              path="folder"
+              element={<PublicFolderView sharedDocumentId={sharedDocumentId} />}
+            >
               <Route path="file/:fileId/revision" element={<FileHistory />} />
               <Route
                 path="paywall"
                 element={<OnlyOfficePaywallView isPublic={true} />}
               />
             </Route>
-            <Route path="folder/:folderId" element={<PublicFolderView />}>
+            <Route
+              path="folder/:folderId"
+              element={<PublicFolderView sharedDocumentId={sharedDocumentId} />}
+            >
               <Route path="file/:fileId" element={<PublicFileViewer />} />
               <Route path="file/:fileId/revision" element={<FileHistory />} />
               <Route


### PR DESCRIPTION
When displaying a shared folder, the breadcrumb only displayed the shared folder and parent in breadcrumb. Now we display the full breadcrumb from the current folder to the root of the public folder.

[Capture vidéo du 2025-12-16 17-58-04.webm](https://github.com/user-attachments/assets/e1faa6ab-73c3-4d5b-913b-ccb40fae2662)

https://www.notion.so/linagora/I-don-t-see-my-all-breadcrumb-in-public-link-2b862718bad180c4ae30c95acdf3bcd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs for public/shared folder views now reliably show the correct hierarchy, display only after the path is resolved, and reset on failure (errors are logged).

* **Refactor**
  * Breadcrumb resolution moved to an asynchronous, client-side traversal for more robust parent-folder lookup.
  * Public folder view and routing now pass shared-document context through the view so breadcrumbs are built consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->