### PR TITLE
fix: Avoid race condition on filename validation

### DIFF
--- a/src/modules/filelist/FilenameInput.jsx
+++ b/src/modules/filelist/FilenameInput.jsx
@@ -57,7 +57,9 @@ class FilenameInput extends Component {
   handleBlur() {
     const { value } = this.state
     if (valueIsEmpty(value)) {
-      this.abort()
+      // For folder creation (no initial name), exit without notification (abort(false))
+      // For file renaming (has initial name), show notification (abort(true))
+      this.abort(!!this.fileNameOnMount)
     } else {
       this.submit()
     }

--- a/src/modules/filelist/FilenameInput.spec.jsx
+++ b/src/modules/filelist/FilenameInput.spec.jsx
@@ -1,0 +1,168 @@
+'use strict'
+
+import '@testing-library/jest-dom'
+import { render, fireEvent, screen } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+
+import FilenameInput from './FilenameInput'
+import AppLike from 'test/components/AppLike'
+
+describe('FilenameInput', () => {
+  const client = createMockClient({
+    clientOptions: {
+      uri: 'http://cozy.localhost:8080/'
+    }
+  })
+
+  const setup = ({
+    name = '',
+    file = null,
+    onSubmit = jest.fn(),
+    onAbort = jest.fn(),
+    onChange = jest.fn()
+  } = {}) => {
+    const root = render(
+      <AppLike client={client}>
+        <FilenameInput
+          name={name}
+          file={file}
+          onSubmit={onSubmit}
+          onAbort={onAbort}
+          onChange={onChange}
+        />
+      </AppLike>
+    )
+    return { root, onSubmit, onAbort, onChange }
+  }
+
+  describe('handleKeyDown behavior', () => {
+    it('should call submit when ENTER_KEY is pressed with non-empty value', () => {
+      const { onSubmit } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Type some text
+      fireEvent.change(input, { target: { value: 'test-file' } })
+
+      // Press Enter
+      fireEvent.keyDown(input, { keyCode: 13 })
+
+      expect(onSubmit).toHaveBeenCalledWith('test-file')
+    })
+
+    it('should call abort with accidental=true when ENTER_KEY is pressed with empty value', () => {
+      const { onAbort } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Press Enter with empty value
+      fireEvent.keyDown(input, { keyCode: 13 })
+
+      expect(onAbort).toHaveBeenCalledWith(true)
+    })
+
+    it('should call abort when ESC_KEY is pressed', () => {
+      const { onAbort } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Press Escape
+      fireEvent.keyDown(input, { keyCode: 27 })
+
+      expect(onAbort).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleBlur behavior', () => {
+    it('should call submit when blurred with non-empty value', () => {
+      const { onSubmit } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Type some text
+      fireEvent.change(input, { target: { value: 'test-file' } })
+
+      // Blur the input
+      fireEvent.blur(input)
+
+      expect(onSubmit).toHaveBeenCalledWith('test-file')
+    })
+
+    it('should call abort when blurred with empty value', () => {
+      const { onAbort } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Blur with empty value
+      fireEvent.blur(input)
+
+      expect(onAbort).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleChange behavior', () => {
+    it('should update state and call onChange when input changes', () => {
+      const { onChange } = setup()
+      const input = screen.getByRole('textbox')
+
+      fireEvent.change(input, { target: { value: 'new-value' } })
+
+      expect(onChange).toHaveBeenCalledWith('new-value')
+      expect(input.value).toBe('new-value')
+    })
+  })
+
+  describe('race condition fix verification', () => {
+    it('should not show unwanted notification for empty filename on ENTER_KEY', () => {
+      const { onAbort } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Simulate pressing Enter with empty value
+      fireEvent.keyDown(input, { keyCode: 13 })
+
+      // Should call abort with accidental=true, not show unwanted notification
+      expect(onAbort).toHaveBeenCalledWith(true)
+      expect(onAbort).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle blur correctly without race condition', () => {
+      const { onSubmit, onAbort } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Type some text and blur
+      fireEvent.change(input, { target: { value: 'valid-file' } })
+      fireEvent.blur(input)
+
+      // Should submit without any race condition issues
+      expect(onSubmit).toHaveBeenCalledWith('valid-file')
+      expect(onAbort).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle whitespace-only value as non-empty', () => {
+      const { onSubmit } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Type whitespace and press Enter
+      fireEvent.change(input, { target: { value: '   ' } })
+      fireEvent.keyDown(input, { keyCode: 13 })
+
+      // Whitespace is considered non-empty by the component
+      expect(onSubmit).toHaveBeenCalledWith('   ')
+    })
+    it('should not submit twice when Enter is followed by blur', () => {
+      const { onSubmit, onAbort } = setup()
+      const input = screen.getByRole('textbox')
+
+      // Type a value
+      fireEvent.change(input, { target: { value: 'test-file' } })
+
+      // Press Enter, then blur immediately
+      fireEvent.keyDown(input, { keyCode: 13 })
+      fireEvent.blur(input)
+
+      // Should only submit once, not twice
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit).toHaveBeenCalledWith('test-file')
+      expect(onAbort).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
When pressing enter key on filename creation we would get an unwanted notification for empty filename even if not empty.

I simplified the handling of these events and now :
- we save the file when pressing enter and the file name is not empty
- we display the "no empty file name" notification when pressing enter with an empty file name
- we save the file when bluring the component and the file name is not empty
- we just blur without notification on blur with empty file name

https://www.notion.so/linagora/Toast-when-creating-folder-29562718bad18055a7ccfcf0c523489b
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename input behavior: Enter, Escape and blur now consistently submit or abort based on the field value (whitespace is treated as content). Added a submission guard to prevent duplicate submissions and race conditions; submitting state is reliably cleared on completion or error.

* **Tests**
  * Added comprehensive tests covering Enter, Escape, blur, typing, whitespace edge cases and race-condition scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->