### PR TITLE
fix: Early return when currentFolderId equals rootBreadcrumbPath.id

### DIFF
--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.jsx
@@ -38,6 +38,11 @@ export const useBreadcrumbPath = ({
   }
 
   useEffect(() => {
+    if (rootBreadcrumbPath && currentFolderId === rootBreadcrumbPath.id) {
+      setPaths([rootBreadcrumbPath])
+      return
+    }
+
     if (!folderAttributes.id || !folderAttributes.name) {
       // Optionally set loading state or clear paths
       setPaths([])
@@ -117,7 +122,8 @@ export const useBreadcrumbPath = ({
     driveId,
     folderAttributes.id,
     folderAttributes.name,
-    folderAttributes.dirId
+    folderAttributes.dirId,
+    currentFolderId
   ])
 
   return paths

--- a/src/modules/breadcrumb/hooks/useBreadcrumbPath.spec.jsx
+++ b/src/modules/breadcrumb/hooks/useBreadcrumbPath.spec.jsx
@@ -76,6 +76,30 @@ describe('useBreadcrumbPath', () => {
     expect(render.result.current).toEqual([dummyRootBreadcrumbPath()])
   })
 
+  it('should return only rootBreadcrumbPath when currentFolderId equals rootBreadcrumbPath.id (early return)', async () => {
+    const someFolderId = 'some-folder-id'
+    useFolder.mockReturnValue(
+      createFolder({
+        id: someFolderId,
+        name: 'Some Folder',
+        dirId: rootBreadcrumbPath.id
+      })
+    )
+
+    let render
+    await act(async () => {
+      render = await renderHook(() =>
+        useBreadcrumbPath({
+          rootBreadcrumbPath,
+          currentFolderId: rootBreadcrumbPath.id
+        })
+      )
+    })
+
+    expect(render.result.current).toEqual([rootBreadcrumbPath])
+    expect(fetchFolder).not.toHaveBeenCalled()
+  })
+
   it('should call fetch folder', async () => {
     // Given
     const currentFolderId = '1234'


### PR DESCRIPTION
This fixes the bredcrumb for the root folder and the trash folder by displaying the breadcrumb for the root folder directly

[Capture vidéo du 2025-12-18 19-49-00.webm](https://github.com/user-attachments/assets/601ed9d9-0ab0-4c11-a95a-b65ba3f6fe52)

https://www.notion.so/linagora/Problem-with-breadcrumbs-in-trash-2c862718bad180bb8dd1d65789fde48d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumb now correctly updates when the active folder changes.
  * Improved breadcrumb performance by skipping unnecessary processing when at the root folder.

* **Tests**
  * Added test coverage for breadcrumb behavior when navigating to the root folder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->