### PR TITLE
fix: Add ellipsis to delete confirm title

### DIFF
--- a/src/modules/drive/DeleteConfirm.jsx
+++ b/src/modules/drive/DeleteConfirm.jsx
@@ -119,11 +119,15 @@ export const DeleteConfirm = ({
     <ConfirmDialog
       open={true}
       onClose={onClose}
-      title={t('DeleteConfirm.title', {
-        filename: splitFilename(files[0]).filename,
-        smart_count: fileCount,
-        type: entriesType
-      })}
+      title={
+        <Typography variant="h3" className="u-ellipsis">
+          {t('DeleteConfirm.title', {
+            filename: splitFilename(files[0]).filename,
+            smart_count: fileCount,
+            type: entriesType
+          })}
+        </Typography>
+      }
       content={
         <Stack>
           <Message type="trash" fileCount={fileCount} />


### PR DESCRIPTION
To not break the layout, we add an ellipsis to the title of the delete confirm dialog with a long filename.

Before : 
<img width="491" height="286" alt="image" src="https://github.com/user-attachments/assets/c99669de-a5d6-4a3f-a40c-d305fbb9a03b" />

After:
<img width="491" height="286" alt="image" src="https://github.com/user-attachments/assets/1d640662-84b8-41e5-9010-9b97b1e89bc8" />

Could not use `dialogTitleProps` or `componentProps.dialogTitle` since "u-ellipsis" class is overridden by ConfirmDialog.component 

https://www.notion.so/linagora/Delete-modal-long-file-name-2bf62718bad180a6b960c6c23d69dbd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the styling of the delete confirmation dialog title with enhanced typography formatting and text overflow handling for better visual presentation and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->