### PR TITLE
fix: Avoid full rerender of the file viewer

### DIFF
--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -178,7 +178,6 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
 
   return (
     <RightClickFileMenu
-      key={viewerFiles[viewerIndex]?._id}
       doc={viewerFiles[viewerIndex]}
       actions={actions}
       disabled={!viewerFiles[viewerIndex]}


### PR DESCRIPTION
When navigating between files in the viewer, the component was fully rerendered. 
Removing the key, which is not needed here, fixes the issue.

https://www.notion.so/linagora/File-viewer-2b862718bad180f4b97bdc7beca832d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized component reconciliation in the file viewer for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->