### PR TITLE
fix: Refresh public folder files when uploading multiple files

### DIFF
--- a/src/modules/views/Public/usePublicFilesQuery.jsx
+++ b/src/modules/views/Public/usePublicFilesQuery.jsx
@@ -27,7 +27,7 @@ export const usePublicFilesQuery = currentFolderId => {
   const [hasMore, setHasMore] = useState(false)
 
   const [fetchCounter, updateFetchCounter] = useState(1)
-  const forceRefetch = () => updateFetchCounter(fetchCounter + 1)
+  const forceRefetch = () => updateFetchCounter(prev => prev + 1)
 
   const nextCursor = useRef(null)
 


### PR DESCRIPTION
Updated usePublicFilesQuery to use a functional update for the fetch counter, ensuring that every call correctly increments the state and triggers a refresh.

[Capture vidéo du 2026-01-07 14-52-21.webm](https://github.com/user-attachments/assets/00a2eb55-6d49-4c90-9226-a502363cf6f1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the file refresh mechanism to ensure consistent state management and prevent synchronization issues that could occur with stale state references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->