### PR TITLE
fix: Refresh folder content when uploading file from empty folder view

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -17,7 +17,13 @@ import { isEncryptedFolder } from '@/lib/encryption'
 import UploadButton from '@/modules/upload/UploadButton'
 import CreateSharedDriveButton from '@/modules/views/SharedDrive/CreateSharedDriveButton'
 
-const EmptyCanvas = ({ type, canUpload, localeKey, hasTextMobileVersion }) => {
+const EmptyCanvas = ({
+  type,
+  canUpload,
+  localeKey,
+  hasTextMobileVersion,
+  onUploaded
+}) => {
   const { t } = useI18n()
   const { isDesktop } = useBreakpoints()
   const { displayedFolder } = useDisplayedFolder()
@@ -57,6 +63,7 @@ const EmptyCanvas = ({ type, canUpload, localeKey, hasTextMobileVersion }) => {
                 }}
                 label={t('toolbar.menu_upload')}
                 displayedFolder={displayedFolder}
+                onUploaded={onUploaded}
               />
             </span>
           )}
@@ -91,7 +98,8 @@ export const EmptyTrash = props => (
 export const EmptyWrapper = ({
   currentFolderId,
   displayedFolder,
-  canUpload
+  canUpload,
+  refreshFolderContent
 }) => {
   const { pathname } = useLocation()
 
@@ -103,9 +111,10 @@ export const EmptyWrapper = ({
       <EmptyDrive
         isEncrypted={isEncryptedFolder(displayedFolder)}
         canUpload={canUpload}
+        onUploaded={refreshFolderContent}
       />
     )
   }
 
-  return <EmptyTrash canUpload={canUpload} />
+  return <EmptyTrash canUpload={canUpload} onUploaded={refreshFolderContent} />
 }

--- a/src/modules/views/Folder/virtualized/FolderViewBody.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBody.jsx
@@ -128,6 +128,7 @@ const FolderViewBody = ({
         currentFolderId={currentFolderId}
         displayedFolder={displayedFolder}
         canUpload={canUpload}
+        refreshFolderContent={refreshFolderContent}
       />
     )
   }


### PR DESCRIPTION
When uploading files via the “upload files” button displayed when the folder is empty, the list of files was not refreshed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder refresh functionality after file uploads in empty states.

* **Refactor**
  * Enhanced internal callback mechanism for post-upload actions to ensure consistent folder content updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->