### PR TITLE
fix: Delete key on Mac should be treated as delete

### DIFF
--- a/src/hooks/helpers.js
+++ b/src/hooks/helpers.js
@@ -74,7 +74,7 @@ export const normalizeKey = (event, isApple) => {
 
   const key = event.key.toLowerCase()
 
-  if (key === 'delete' || key === 'del') {
+  if (key === 'delete' || key === 'del' || (isApple && key === 'backspace')) {
     keys.push('delete')
   } else {
     keys.push(key)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backspace on Apple platforms is now treated the same as Delete, fixing inconsistent keyboard behavior.
  * Improves reliability of deletion and shortcut handling on Mac keyboards for more consistent user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->