### PR TITLE
feat: Add missing menu items to the toolbar menu

### DIFF
--- a/src/modules/drive/Toolbar/components/FavoritesItem.jsx
+++ b/src/modules/drive/Toolbar/components/FavoritesItem.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+
+import { useClient } from 'cozy-client'
+import { splitFilename } from 'cozy-client/dist/models/file'
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import StarIcon from 'cozy-ui/transpiled/react/Icons/Star'
+import StarOutlineIcon from 'cozy-ui/transpiled/react/Icons/StarOutline'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+
+const FavoritesItem = ({ displayedFolder }) => {
+  const { showAlert } = useAlert()
+  const { t } = useI18n()
+  const client = useClient()
+
+  const isFavorite = displayedFolder?.cozyMetadata?.favorite
+  const labelKey = isFavorite ? 'remove' : 'add'
+
+  const handleClick = async () => {
+    if (!displayedFolder) return
+
+    try {
+      await client.save({
+        ...displayedFolder,
+        cozyMetadata: {
+          ...displayedFolder.cozyMetadata,
+          favorite: !isFavorite
+        }
+      })
+
+      const { filename } = splitFilename(displayedFolder)
+      showAlert({
+        message: t(`favorites.success.${labelKey}`, {
+          filename,
+          smart_count: 1
+        }),
+        severity: 'success'
+      })
+    } catch (error) {
+      showAlert({ message: t('favorites.error'), severity: 'error' })
+    }
+  }
+
+  const icon = isFavorite ? StarIcon : StarOutlineIcon
+
+  return (
+    <ActionsMenuItem onClick={handleClick}>
+      <ListItemIcon>
+        <Icon icon={icon} />
+      </ListItemIcon>
+      <ListItemText primary={t(`favorites.label.${labelKey}`)} />
+    </ActionsMenuItem>
+  )
+}
+
+export default FavoritesItem

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -9,6 +9,7 @@ import { MoreButton } from '@/components/Button'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
 import AddMenuItem from '@/modules/drive/Toolbar/components/AddMenuItem'
 import DownloadButtonItem from '@/modules/drive/Toolbar/components/DownloadButtonItem'
+import FavoritesItem from '@/modules/drive/Toolbar/components/FavoritesItem'
 import InsideRegularFolder from '@/modules/drive/Toolbar/components/InsideRegularFolder'
 import LeaveSharedDriveButtonItem from '@/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem'
 import ManageAccessItem from '@/modules/drive/Toolbar/components/ManageAccessItem'
@@ -99,6 +100,14 @@ const MoreMenu = ({
             {isMobile && hasWriteAccess && <AddMenuItem />}
             <SelectableItem onClick={showSelectionBar} />
             {isSharedDriveOwner && <ManageAccessItem />}
+            {hasWriteAccess && (
+              <InsideRegularFolder
+                displayedFolder={displayedFolder}
+                folderId={folderId}
+              >
+                <FavoritesItem displayedFolder={displayedFolder} />
+              </InsideRegularFolder>
+            )}
             {hasWriteAccess && (
               <InsideRegularFolder
                 displayedFolder={displayedFolder}

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -14,6 +14,7 @@ import InsideRegularFolder from '@/modules/drive/Toolbar/components/InsideRegula
 import LeaveSharedDriveButtonItem from '@/modules/drive/Toolbar/components/LeaveSharedDriveButtonItem'
 import ManageAccessItem from '@/modules/drive/Toolbar/components/ManageAccessItem'
 import DeleteItem from '@/modules/drive/Toolbar/delete/DeleteItem'
+import MoveItem from '@/modules/drive/Toolbar/move/MoveItem'
 import SelectableItem from '@/modules/drive/Toolbar/selectable/SelectableItem'
 import ShareItem from '@/modules/drive/Toolbar/share/ShareItem'
 
@@ -96,6 +97,10 @@ const MoreMenu = ({
               {!isSharedDriveRecipient && (
                 <DownloadButtonItem files={[displayedFolder]} />
               )}
+              <MoveItem
+                displayedFolder={displayedFolder}
+                hasWriteAccess={hasWriteAccess}
+              />
             </InsideRegularFolder>
             {isMobile && hasWriteAccess && <AddMenuItem />}
             <SelectableItem onClick={showSelectionBar} />

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -81,7 +81,7 @@ const MoreMenu = ({
               horizontal: 'right'
             }}
           >
-            {isMobile && allLoaded && (
+            {allLoaded && (
               <InsideRegularFolder
                 displayedFolder={displayedFolder}
                 folderId={folderId}

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -15,6 +15,7 @@ import LeaveSharedDriveButtonItem from '@/modules/drive/Toolbar/components/Leave
 import ManageAccessItem from '@/modules/drive/Toolbar/components/ManageAccessItem'
 import DeleteItem from '@/modules/drive/Toolbar/delete/DeleteItem'
 import MoveItem from '@/modules/drive/Toolbar/move/MoveItem'
+import PersonalizeFolderItem from '@/modules/drive/Toolbar/personalizeFolder/PersonalizeFolderItem'
 import SelectableItem from '@/modules/drive/Toolbar/selectable/SelectableItem'
 import ShareItem from '@/modules/drive/Toolbar/share/ShareItem'
 
@@ -98,6 +99,10 @@ const MoreMenu = ({
                 <DownloadButtonItem files={[displayedFolder]} />
               )}
               <MoveItem
+                displayedFolder={displayedFolder}
+                hasWriteAccess={hasWriteAccess}
+              />
+              <PersonalizeFolderItem
                 displayedFolder={displayedFolder}
                 hasWriteAccess={hasWriteAccess}
               />

--- a/src/modules/drive/Toolbar/move/MoveItem.jsx
+++ b/src/modules/drive/Toolbar/move/MoveItem.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useI18n } from 'twake-i18n'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import MovetoIcon from 'cozy-ui/transpiled/react/Icons/Moveto'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+
+import { navigateToModalWithMultipleFile } from '@/modules/actions/helpers'
+import { isSharedDriveFolder } from '@/modules/shareddrives/helpers'
+
+const MoveItem = ({ displayedFolder, hasWriteAccess }) => {
+  const { t } = useI18n()
+  const navigate = useNavigate()
+  const { pathname, search } = useLocation()
+  const { isMobile } = useBreakpoints()
+
+  if (!hasWriteAccess || isSharedDriveFolder(displayedFolder)) {
+    return null
+  }
+
+  const handleClick = () => {
+    navigateToModalWithMultipleFile({
+      files: [displayedFolder],
+      pathname,
+      navigate,
+      path: 'move',
+      search
+    })
+  }
+
+  const label = isMobile
+    ? t('SelectionBar.moveto_mobile')
+    : t('SelectionBar.moveto')
+
+  return (
+    <ActionsMenuItem onClick={handleClick}>
+      <ListItemIcon>
+        <Icon icon={MovetoIcon} />
+      </ListItemIcon>
+      <ListItemText primary={label} />
+    </ActionsMenuItem>
+  )
+}
+
+export default MoveItem

--- a/src/modules/drive/Toolbar/personalizeFolder/PersonalizeFolderItem.jsx
+++ b/src/modules/drive/Toolbar/personalizeFolder/PersonalizeFolderItem.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+
+import flag from 'cozy-flags'
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import PaletteIcon from 'cozy-ui/transpiled/react/Icons/Palette'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+import { useModalContext } from '@/lib/ModalContext'
+import { FolderCustomizerModal } from '@/modules/views/Folder/FolderCustomizer'
+
+const PersonalizeFolderItem = ({
+  displayedFolder,
+  hasWriteAccess,
+  onClose
+}) => {
+  const { t } = useI18n()
+  const { pushModal, popModal } = useModalContext()
+
+  if (
+    !flag('drive.folder-personalization.enabled') ||
+    !hasWriteAccess ||
+    !displayedFolder ||
+    displayedFolder.type !== 'directory'
+  ) {
+    return null
+  }
+
+  const handleClick = () => {
+    pushModal(
+      <FolderCustomizerModal
+        folderId={displayedFolder.id}
+        driveId={displayedFolder.driveId}
+        onClose={() => {
+          popModal()
+          onClose?.()
+        }}
+      />
+    )
+  }
+
+  return (
+    <ActionsMenuItem onClick={handleClick}>
+      <ListItemIcon>
+        <Icon icon={PaletteIcon} />
+      </ListItemIcon>
+      <ListItemText primary={t('actions.personalizeFolder.label')} />
+    </ActionsMenuItem>
+  )
+}
+
+export default PersonalizeFolderItem


### PR DESCRIPTION
I had to create new actions since existing ones are meant to be used as a children of the action menu.

Actions added:
- add to favorites
- remove from favorites
- share : even if duplicated with the sharing badge, it helps users to find the command
- personalize folder

<img width="345" height="389" alt="image" src="https://github.com/user-attachments/assets/55d345e4-6bc8-48a5-89d6-bc5dfe8d1dbf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Favorites menu item to mark/unmark files and folders with localized success/error alerts and item name.
  * Move menu item to open a move dialog while preserving navigation context and showing mobile/desktop labels.
  * Personalize Folder menu item to open a folder customization modal when feature enabled and permitted.
* **UI**
  * Reorganized "More" menu to surface these actions for writable folders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->