### PR TITLE
fix: Ensure fileUploadedCallback is a function before invoking

### DIFF
--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -114,6 +114,7 @@ const uploadQueueProcessed =
     addItems
   ) =>
   dispatch => {
+    const safeAddItems = typeof addItems === 'function' ? addItems : () => {}
     const conflictCount = conflicts.length
     const createdCount = created.length
     const updatedCount = updated.length
@@ -126,7 +127,7 @@ const uploadQueueProcessed =
     // Add new items to the NewContext
     const successfulUploads = [...created, ...updated]
     if (successfulUploads.length > 0) {
-      addItems(successfulUploads)
+      safeAddItems(successfulUploads)
     }
 
     // Add logging to debug upload completion
@@ -274,6 +275,7 @@ export const createFolder = (
   driveId,
   addItems = () => {}
 ) => {
+  const safeAddItems = typeof addItems === 'function' ? addItems : () => {}
   return async (dispatch, getState) => {
     const state = getState()
     let targetFolderId = currentFolderId
@@ -329,7 +331,7 @@ export const createFolder = (
 
       // Add newly created folder to new items
       if (createdFolder) {
-        addItems([createdFolder.data])
+        safeAddItems([createdFolder.data])
       }
 
       if (navigateAfterCreate && createdFolder) {

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -68,23 +68,23 @@ export const uploadFiles =
         targetDirId,
         sharingState,
         fileUploadedCallback,
-        (
-          loaded,
+        ({
+          createdItems,
           quotas,
           conflicts,
           networkErrors,
           errors,
-          updated,
+          updatedItems,
           fileTooLargeErrors
-        ) =>
+        }) =>
           dispatch(
             uploadQueueProcessed(
-              loaded,
+              createdItems,
               quotas,
               conflicts,
               networkErrors,
               errors,
-              updated,
+              updatedItems,
               showAlert,
               t,
               fileTooLargeErrors,

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -528,7 +528,7 @@ export const onQueueEmpty = callback => (dispatch, getState) => {
     .map(item => item.uploadedItem)
     .filter(item => item && item._id)
 
-  return safeCallback(
+  return safeCallback({
     createdItems,
     quotas,
     conflicts,
@@ -536,7 +536,7 @@ export const onQueueEmpty = callback => (dispatch, getState) => {
     errors,
     updatedItems,
     fileTooLargeErrors
-  )
+  })
 }
 
 // selectors

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -187,6 +187,10 @@ export const processNextFile =
     addItems
   ) =>
   async (dispatch, getState) => {
+    const safeCallback =
+      typeof fileUploadedCallback === 'function'
+        ? fileUploadedCallback
+        : () => {}
     let error = null
     if (!client) {
       throw new Error(
@@ -215,7 +219,7 @@ export const processNextFile =
           },
           driveId
         )
-        fileUploadedCallback(newDir)
+        safeCallback(newDir)
         dispatch({ type: RECEIVE_UPLOAD_SUCCESS, file, uploadedItem: newDir })
       } else {
         const withProgress = {
@@ -235,7 +239,7 @@ export const processNextFile =
           },
           driveId
         )
-        fileUploadedCallback(uploadedFile)
+        safeCallback(uploadedFile)
         dispatch({
           type: RECEIVE_UPLOAD_SUCCESS,
           file,
@@ -261,7 +265,7 @@ export const processNextFile =
             },
             driveId
           )
-          fileUploadedCallback(uploadedFile)
+          safeCallback(uploadedFile)
           dispatch({
             type: RECEIVE_UPLOAD_SUCCESS,
             file,
@@ -506,6 +510,7 @@ export const addToUploadQueue =
 export const purgeUploadQueue = () => ({ type: PURGE_UPLOAD_QUEUE })
 
 export const onQueueEmpty = callback => (dispatch, getState) => {
+  const safeCallback = typeof callback === 'function' ? callback : () => {}
   const queue = getUploadQueue(getState())
   const quotas = getQuotaErrors(queue)
   const conflicts = getConflicts(queue)
@@ -523,7 +528,7 @@ export const onQueueEmpty = callback => (dispatch, getState) => {
     .map(item => item.uploadedItem)
     .filter(item => item && item._id)
 
-  return callback(
+  return safeCallback(
     createdItems,
     quotas,
     conflicts,

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -66,15 +66,15 @@ describe('processNextFile function', () => {
       client: fakeClient
     })
     result(dispatchSpy, getState)
-    expect(queueCompletedCallbackSpy).toHaveBeenCalledWith(
-      [],
-      [],
-      [],
-      [],
-      [],
-      [],
-      []
-    )
+    expect(queueCompletedCallbackSpy).toHaveBeenCalledWith({
+      createdItems: [],
+      quotas: [],
+      conflicts: [],
+      networkErrors: [],
+      errors: [],
+      updatedItems: [],
+      fileTooLargeErrors: []
+    })
   })
 
   it('should process files in the queue', async () => {


### PR DESCRIPTION
Added checks to verify that fileUploadedCallback is a function before calling it in the processNextFile function, preventing potential runtime errors during file uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime guards to validate callbacks before invocation during file uploads and queue processing, preventing calls to non-function values and reducing runtime errors.
  * Standardized upload-queue result shape to use clearer result fields (created/updated items, errors, quotas, conflicts, etc.).

* **Tests**
  * Updated queue-completion test expectations to match the new result structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->