### PR TITLE
feat: Upgrade cozy-sharing to 28.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.14.1",
-    "cozy-sharing": "^28.2.1",
+    "cozy-sharing": "^28.3.0",
     "cozy-stack-client": "^60.19.0",
     "cozy-ui": "^135.3.0",
     "cozy-ui-plus": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,10 +5838,10 @@ cozy-search@^0.14.1:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^28.2.1:
-  version "28.2.1"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.2.1.tgz#4e459c9782dfbe8be2bbac722634a794b6c2771e"
-  integrity sha512-Nms5Gsbir9z2E/FgfDFjVaxb7q0XIz9ivQzHNAdcjO6CNLXlqHxCTl6XTB+GCashDHKujiJXV5Tir5u/LyI08g==
+cozy-sharing@^28.3.0:
+  version "28.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.3.0.tgz#46eb42bda68890e431d346f30c9ac1f114f23588"
+  integrity sha512-OlPmum/fFQR61sEnSotzsfMTaMuM6bKIR1kw9eVE0mbeRb/hliGKJ8kEF7olAIqLIaNGbUXNrzQ0Dzg4Lx0peg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
To get https://github.com/linagora/cozy-libs/pull/2916 and allow user to create sharing link in one click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest compatible version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->