### PR TITLE
fix: Hide summarize button in public view :bug:

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "cozy-stack-client": "^60.19.0",
     "cozy-ui": "^135.6.0",
     "cozy-ui-plus": "^4.4.0",
-    "cozy-viewer": "^26.6.0",
+    "cozy-viewer": "^26.6.1",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",
     "filesize": "10.1.6",

--- a/src/modules/actions/summariseByAI.jsx
+++ b/src/modules/actions/summariseByAI.jsx
@@ -25,7 +25,7 @@ const makeComponent = (label, icon) => {
   return Component
 }
 
-export const summariseByAI = ({ t, hasWriteAccess, navigate }) => {
+export const summariseByAI = ({ t, hasWriteAccess, navigate, isPublic }) => {
   const label = t('actions.summariseByAI')
   const icon = ArticleIcon
 
@@ -36,7 +36,8 @@ export const summariseByAI = ({ t, hasWriteAccess, navigate }) => {
     displayCondition: files =>
       flag('ai.available') &&
       isFileSummaryCompatible(files[0]) &&
-      hasWriteAccess,
+      hasWriteAccess &&
+      !isPublic,
     action: files => {
       const file = files[0]
       navigate(`file/${file._id}`, {

--- a/src/modules/public/LightFileViewer.jsx
+++ b/src/modules/public/LightFileViewer.jsx
@@ -78,7 +78,11 @@ const LightFileViewer = ({ files, isPublic }) => {
               isEnabled: isOfficeEnabled(isDesktop),
               opener: onlyOfficeOpener
             },
-            toolbarProps: { showToolbar: isDesktop, showClose: false }
+            toolbarProps: {
+              showToolbar: isDesktop,
+              showClose: false,
+              hideSummarizeBtn: true
+            }
           }}
         >
           <FooterActionButtons>

--- a/src/modules/views/Public/PublicFileViewer.jsx
+++ b/src/modules/views/Public/PublicFileViewer.jsx
@@ -88,6 +88,11 @@ const PublicFileViewer = () => {
       isPublic={true}
       onChangeRequest={handleChange}
       onCloseRequest={handleClose}
+      componentsProps={{
+        toolbarProps: {
+          hideSummarizeBtn: true
+        }
+      }}
     >
       <FooterActionButtons>
         <ForwardOrDownloadButton />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,10 +5922,10 @@ cozy-ui@^135.6.0:
     react-virtuoso "^4.13.0"
     rooks "7.14.1"
 
-cozy-viewer@^26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-26.6.0.tgz#520e3050599e6ce3a5d2770b2b2e93ced3a8eb7a"
-  integrity sha512-AUVBGPTRNu5mFvMIo6os1qxrkMUoRNd7outtPMdvwFkp6lgumExML8Vy4mgUsI1hCjtbVOaL48+gvyl2M/iPoA==
+cozy-viewer@^26.6.1:
+  version "26.6.1"
+  resolved "https://registry.yarnpkg.com/cozy-viewer/-/cozy-viewer-26.6.1.tgz#c79ff3d55de63a5927a49d6525fafebba0deb438"
+  integrity sha512-RB0/25X/8YWq6RXYLjKaTzZJAY57dIWE0yFhfW/kkazZTPQMUIei22CSbtSQL+rfGHYMN9wLefwRNDLSwqq4GA==
   dependencies:
     classnames "^2.5.1"
     hammerjs "^2.0.8"


### PR DESCRIPTION
### Change:

The button `Summarise` should be hidden in public view.

### Result:

https://github.com/user-attachments/assets/415859d3-fc10-4af4-8393-b23d304a3365

### Needs:

https://github.com/linagora/cozy-libs/pull/2919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI summarization is now hidden for publicly shared files and only available for private files when the user has write access.
  * Public file viewers now hide the summarize button in the toolbar.

* **Chores**
  * Updated viewer dependency to a newer patch version for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->