### PR TITLE
fix: Set the container of dynamic selection to window

### DIFF
--- a/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
@@ -45,8 +45,6 @@ const FolderViewBodyContent = ({
   refreshFolderContent
 }) => {
   const folderViewRef = useRef()
-  // Store the drag container element to force re-render when it becomes available
-  const [dragContainerElement, setDragContainerElement] = useState(null)
   // Stores the actual scroll container HTMLElement from virtuoso's scrollerRef callback.
   // This is needed because virtuosoRef.current only exposes the handle API (scrollTo, scrollBy, etc.),
   // not the DOM element required for RectangularSelection's auto-scroll functionality.
@@ -187,14 +185,13 @@ const FolderViewBodyContent = ({
       folder={displayedFolder}
       onDismiss={handleFolderUnlockerDismiss}
     >
-      <div ref={setDragContainerElement} className="u-h-100 u-w-100">
+      <div className="u-h-100 u-w-100">
         <SelectionBar actions={actions} />
         {isDynamicSelectionEnabled ? (
           <RectangularSelection
             items={sortedRows}
             scrollContainerRef={folderViewRef}
             scrollElement={scrollElement}
-            dragContainer={dragContainerElement}
           >
             {viewContent}
           </RectangularSelection>


### PR DESCRIPTION
We want to be able to start the drag selection from anywhere on the page and also clear the selection from anywhere on the page.

[Capture vidéo du 2026-02-04 14-15-41.webm](https://github.com/user-attachments/assets/6011d560-398c-4129-b32b-6d1beadb4a79)


Also removed the logic to get the element corresponding to container

https://www.notion.so/linagora/Dynamic-selection-fixes-2fd62718bad180809010e3f9eae9d0c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Selection now waits until its container is ready using a ref-based readiness model for more reliable mounting and rendering.
  * Removed external drag-container input from the public API; selection now uses the global drag context.
  * Preserved scroll container and scroll element support to maintain auto-scroll behavior during selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->