### PR TITLE
feat: Treat not scanned files as infected files

### DIFF
--- a/src/modules/actions/trash.jsx
+++ b/src/modules/actions/trash.jsx
@@ -54,6 +54,7 @@ export const trash = ({
     name: 'trash',
     icon,
     allowInfectedFiles: true,
+    allowNotScannedFiles: true,
     displayCondition: files => files.length > 0 && hasWriteAccess,
     action: files => {
       return pushModal(

--- a/src/modules/actions/types.ts
+++ b/src/modules/actions/types.ts
@@ -12,6 +12,8 @@ export interface ActionPolicyContext {
   files: IOCozyFile[]
   /** Whether any file in the selection is infected */
   hasInfectedFile: boolean
+  /** Whether any file has not been scanned yet */
+  hasNotScannedFile: boolean
   /** Whether multiple files are selected */
   hasMultipleFiles: boolean
   /** Whether any file is a folder */
@@ -44,6 +46,7 @@ export interface ActionPolicyDefinition {
  */
 export interface DriveActionPolicyFlags {
   allowInfectedFiles?: boolean
+  allowNotScannedFiles?: boolean
   allowMultiple?: boolean
   allowFolders?: boolean
   allowTrashed?: boolean

--- a/src/modules/filelist/helpers.ts
+++ b/src/modules/filelist/helpers.ts
@@ -68,3 +68,10 @@ export const isInfected = (
 ): boolean => {
   return file?.antivirus_scan?.status === 'infected'
 }
+
+export const isNotScanned = (
+  file?: (FileWithAntivirusScan & Partial<IOCozyFile>) | null
+): boolean => {
+  const status = file?.antivirus_scan?.status
+  return status === 'pending' || status === 'skipped' || status === 'error'
+}


### PR DESCRIPTION
With the `drive.not-scanned-file-action.enabled` flag

When this flag is enabled, the user cannot do any action on files which are not scanned, "remove" action excepted.

https://www.notion.so/linagora/Antivirus-CNB-2fd62718bad1801da516c5831272425b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for not-yet-scanned files: actions can be allowed to operate on files with pending/incomplete antivirus scans when explicitly enabled.
  * Introduced an opt-in option to permit specific actions (e.g., trash) on such files.

* **Policies**
  * New enforcement that blocks actions on not-scanned files unless the action is explicitly allowed.

* **Tests**
  * Added tests covering allow/block behavior across pending, allowed, and disallowed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->