### PR TITLE
fix: extend interactive elements selector to preserve selection when …

### DIFF
--- a/src/modules/selection/RectangularSelection.jsx
+++ b/src/modules/selection/RectangularSelection.jsx
@@ -4,6 +4,9 @@ import Selecto from 'react-selecto'
 import styles from './RectangularSelection.styl'
 import { useSelectionContext } from './SelectionProvider'
 
+const INTERACTIVE_ELEMENTS_SELECTOR =
+  'button,a,input,select,textarea,label,[role="button"],[role="menuitem"],[role="option"]'
+
 /**
  * Component that enables rectangular selection of files in a grid view.
  * Wraps children with a selection area that allows users to drag-select
@@ -102,9 +105,7 @@ const RectangularSelection = ({
     const target = e.inputEvent?.target
     if (!target) return true
 
-    const isInteractive = target.closest(
-      'button,a,input,select,textarea,[role="button"]'
-    )
+    const isInteractive = target.closest(INTERACTIVE_ELEMENTS_SELECTOR)
     if (isInteractive) return false
 
     const fileElement = target.closest('[data-file-id]')
@@ -177,9 +178,7 @@ const RectangularSelection = ({
       const isOnFile = target.closest('[data-file-id]')
       if (isOnFile) return
 
-      const isInteractive = target.closest(
-        'button,a,input,select,textarea,[role="button"]'
-      )
+      const isInteractive = target.closest(INTERACTIVE_ELEMENTS_SELECTOR)
       if (isInteractive) return
 
       // If clicked in empty space, clear selection


### PR DESCRIPTION
…clicking menu items

This way, when we try to rename a file or folder, the focus on the input element is not lost

https://www.notion.so/linagora/Dynamic-selection-fixes-2fd62718bad180809010e3f9eae9d0c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code consolidation for improved maintainability. No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->