### PR TITLE
fix: Allow to create a folder in an empty shared drive

### DIFF
--- a/src/modules/views/Folder/virtualized/AddFolderWrapper.jsx
+++ b/src/modules/views/Folder/virtualized/AddFolderWrapper.jsx
@@ -55,6 +55,7 @@ const AddFolderWrapper = ({
               vaultClient={vaultClient}
               currentFolderId={currentFolderId}
               refreshFolderContent={refreshFolderContent}
+              driveId={driveId}
             />
           </TableCell>
           <TableCell>—</TableCell>


### PR DESCRIPTION
It actually did not work only in table mode. Now we passe the driveId in this case and the correct folder creation request is sent.

https://www.notion.so/linagora/Shared-drives-bugs-and-regretions-2fe62718bad1800c84abc649aea27e15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated folder management to ensure consistent property handling across different render paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->