### PR TITLE
fix: Do not allow to create shortcuts for shared drive recipients

### DIFF
--- a/src/modules/drive/AddMenu/AddMenuContent.jsx
+++ b/src/modules/drive/AddMenu/AddMenuContent.jsx
@@ -18,6 +18,7 @@ import CreateShortcut from '@/modules/drive/Toolbar/components/CreateShortcut'
 import { ScannerMenuItem } from '@/modules/drive/Toolbar/components/Scanner/ScannerMenuItem'
 import { useScannerContext } from '@/modules/drive/Toolbar/components/Scanner/ScannerProvider'
 import UploadItem from '@/modules/drive/Toolbar/components/UploadItem'
+import { isFolderFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
 import { NewItemHighlightProvider } from '@/modules/upload/NewItemHighlightProvider'
 import { isOfficeEditingEnabled } from '@/modules/views/OnlyOffice/helpers'
 
@@ -111,13 +112,14 @@ const AddMenuContent = forwardRef(
               />
             </>
           )}
-        {!isEncryptedFolder && (
-          <CreateShortcut
-            onCreated={refreshFolderContent}
-            onClick={onClick}
-            isReadOnly={isReadOnly}
-          />
-        )}
+        {!isEncryptedFolder &&
+          !isFolderFromSharedDriveRecipient(displayedFolder) && (
+            <CreateShortcut
+              onCreated={refreshFolderContent}
+              onClick={onClick}
+              isReadOnly={isReadOnly}
+            />
+          )}
         {canUpload && !isUploadDisabled && (
           <NewItemHighlightProvider>
             <Divider className="u-mv-half" />


### PR DESCRIPTION
As this is not implemented on back

https://www.notion.so/linagora/Hide-shortcuts-action-for-Shared-Drives-30262718bad1802e9ad4e397b8a74334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Create Shortcut feature to correctly handle shared drive recipient folders, ensuring proper functionality across different folder types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->