### PR TITLE
fix: Handle page title for recents, sharings and shared drives

### DIFF
--- a/src/components/useHead.jsx
+++ b/src/components/useHead.jsx
@@ -10,7 +10,7 @@ import {
   buildSharedDriveFolderQuery
 } from '@/queries'
 
-const useHead = () => {
+const useHead = ({ title } = {}) => {
   const { driveId, folderId, fileId } = useParams()
 
   const isFileOpen = useMemo(() => fileId !== undefined, [fileId])
@@ -26,7 +26,7 @@ const useHead = () => {
     fileQuery.options
   )
 
-  useUpdateDocumentTitle(file, fetchStatus)
+  useUpdateDocumentTitle(file, fetchStatus, title)
   useUpdateFavicon(file, fetchStatus)
 }
 

--- a/src/modules/views/Recent/index.jsx
+++ b/src/modules/views/Recent/index.jsx
@@ -66,7 +66,7 @@ export const RecentView = () => {
   const { isNativeFileSharingAvailable, shareFilesNative } =
     useNativeFileSharing()
   const dispatch = useDispatch()
-  useHead()
+  useHead({ title: t('breadcrumb.title_recent') })
   const { showAlert } = useAlert()
   const [sortOrder, setSortOrder, isSettingsLoaded] =
     useFolderSort(RECENT_FOLDER_ID)

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -12,6 +12,7 @@ import { Content } from 'cozy-ui/transpiled/react/Layout'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
+import useHead from '@/components/useHead'
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
 import { useClipboardContext } from '@/contexts/ClipboardProvider'
 import { useDisplayedFolder, useFolderSort } from '@/hooks'
@@ -40,6 +41,7 @@ const SharedDriveFolderView = () => {
   const { pathname } = useLocation()
   const { isMobile } = useBreakpoints()
   const params = useParams()
+  useHead()
   const { driveId, folderId } = params
   const sharingContext = useSharingContext()
   const { isOwner, byDocId, hasWriteAccess, refresh } = sharingContext

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -79,7 +79,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const { isNativeFileSharingAvailable, shareFilesNative } =
     useNativeFileSharing()
   const dispatch = useDispatch()
-  useHead()
+  useHead({ title: t('breadcrumb.title_sharings') })
   const { showAlert } = useAlert()
   const [sortOrder, setSortOrder, isSettingsLoaded] = useFolderSort('sharings')
 

--- a/src/modules/views/useUpdateDocumentTitle.jsx
+++ b/src/modules/views/useUpdateDocumentTitle.jsx
@@ -48,7 +48,7 @@ export const makeTitle = (file, appFullName, t) => {
   return `${fileName}${path}${separator}${appFullName}`
 }
 
-const useUpdateDocumentTitle = (file, fetchStatus) => {
+const useUpdateDocumentTitle = (file, fetchStatus, customTitle) => {
   const { t } = useI18n()
   const client = useClient()
 
@@ -57,16 +57,19 @@ const useUpdateDocumentTitle = (file, fetchStatus) => {
     [client.appMetadata]
   )
 
-  const title = useMemo(
-    () => makeTitle(file, appFullName, t),
-    [file, appFullName, t]
-  )
+  const title = useMemo(() => {
+    if (customTitle) {
+      return `${customTitle} - ${appFullName}`
+    }
+    return makeTitle(file, appFullName, t)
+  }, [file, appFullName, t, customTitle])
 
   useEffect(() => {
-    if (fetchStatus === 'loaded' && title !== document.title) {
+    const shouldUpdate = customTitle || fetchStatus === 'loaded'
+    if (shouldUpdate && title && title !== document.title) {
       document.title = title
     }
-  }, [fetchStatus, title])
+  }, [fetchStatus, title, customTitle])
 }
 
 export default useUpdateDocumentTitle

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -654,7 +654,8 @@ export const buildSharedDriveFolderQuery: QueryBuilder<
     as: `io.cozy.files/driveId/${driveId}/folderId/${folderId}`,
     // fetchPolicy: defaultFetchPolicy, // FIXME we do not use cache here to get the "included" part of the result of the query
     // see https://github.com/cozy/cozy-client/issues/1620
-    enabled: !!driveId && !!folderId
+    enabled: !!driveId && !!folderId,
+    singleDocData: true
   }
 })
 


### PR DESCRIPTION
https://www.notion.so/linagora/Christophe-Thiriot-1a862718bad180458472c6e628b23dff?p=30262718bad180ef8955d052f2b5a409&pm=s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Page titles now show contextual names for Recent, Sharings, and Shared Drive folder views for clearer browser tabs and breadcrumbs.
  * Document title updates better respect provided/custom titles and update at the appropriate time to reduce flicker and ensure accurate tab text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->