### PR TITLE
feat: Disable Universal link if specified

### DIFF
--- a/src/modules/drive/Toolbar/components/CreateNoteItem.jsx
+++ b/src/modules/drive/Toolbar/components/CreateNoteItem.jsx
@@ -11,6 +11,7 @@ import {
   useCapabilities
 } from 'cozy-client'
 import { isFlagshipApp } from 'cozy-device-helper'
+import flag from 'cozy-flags'
 import { useWebviewIntent } from 'cozy-intent'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -50,7 +51,10 @@ const CreateNoteItem = ({
   const notesAppUrl = url
 
   let returnUrl = ''
-  if (isFlagshipApp() && webviewIntent) {
+  if (
+    (isFlagshipApp() && webviewIntent) ||
+    flag('cozy.universal-link.disabled') === true
+  ) {
     returnUrl = generateWebLink({
       slug: 'drive',
       cozyUrl: client.getStackClient().uri,


### PR DESCRIPTION
Today our Universal links redirection rely on a static predefined list of trusted domains.

And since we start to have a lot of different domains everywhere, it starts to be difficult to manage.

So having the capability to disabled UL for some context / env can be great.

At the end, maybe we'll remove UL at all in our product, because I don't think we need it anymore since we've the flagship app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling for note creation across different app configurations, with enhanced support for universal link management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->