### PR TITLE
fix: Wrong padding on file list

### DIFF
--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -147,7 +147,7 @@ const Table = forwardRef(
 
     return (
       <div
-        className={cx('u-h-100', styles['fil-file-list-container'])}
+        className={cx('u-h-100', 'u-pl-1', styles['fil-file-list-container'])}
         ref={ref}
         tabIndex={0}
         style={{ outline: 'none' }}

--- a/src/styles/filelist.styl
+++ b/src/styles/filelist.styl
@@ -2,7 +2,6 @@
 @require 'settings/z-index.styl'
 
 .fil-file-list-container
-    padding 0 2rem
     &:focus-visible
         outline 0
 


### PR DESCRIPTION
This is a regression from rectangular selection
Now, we have no padding for mobile to get the same UI as before And we just add 1rem of left padding on desktop to get a space to start rectangular selection

<img width="286" height="433" alt="image" src="https://github.com/user-attachments/assets/eaf260a6-6329-454e-9b5f-3b227c103f47" />

<img width="471" height="416" alt="image" src="https://github.com/user-attachments/assets/771d2e26-4c37-46c4-9b09-1f712cc07b81" />

https://www.notion.so/linagora/Mobile-drive-file-preview-screen-navigation-cleanup-context-menu-30b62718bad1801989dfc3abf4762918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined padding and spacing adjustments in folder and file list views for improved visual alignment
  * Enhanced responsive layout behavior with targeted design adjustments for medium and small screen sizes to optimize display across devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->