### PR TITLE
feat: Toolbar changes on mobile

### DIFF
--- a/src/modules/drive/Toolbar/index.jsx
+++ b/src/modules/drive/Toolbar/index.jsx
@@ -41,6 +41,20 @@ const Toolbar = ({
     isFolderFromSharedDriveRecipient(displayedFolder)
   const isSharedDriveOwner = isFolderFromSharedDriveOwner(displayedFolder)
 
+  const moreMenuProps = {
+    isDisabled,
+    hasWriteAccess,
+    isSharedWithMe,
+    canCreateFolder,
+    canUpload,
+    folderId,
+    displayedFolder,
+    showSelectionBar,
+    isSelectionBarVisible,
+    isSharedDriveRecipient,
+    isSharedDriveOwner
+  }
+
   if (disabled) {
     return null
   }
@@ -70,20 +84,10 @@ const Toolbar = ({
         )}
       </InsideRegularFolder>
       <ViewSwitcher className="u-mr-half" />
-      <MoreMenu
-        isDisabled={isDisabled}
-        hasWriteAccess={hasWriteAccess}
-        isSharedWithMe={isSharedWithMe}
-        canCreateFolder={canCreateFolder}
-        canUpload={canUpload}
-        folderId={folderId}
-        displayedFolder={displayedFolder}
-        showSelectionBar={showSelectionBar}
-        isSelectionBarVisible={isSelectionBarVisible}
-        isSharedDriveRecipient={isSharedDriveRecipient}
-        isSharedDriveOwner={isSharedDriveOwner}
-      />
-      <BarRightOnMobile>{isMobile && <SearchButton />}</BarRightOnMobile>
+      <BarRightOnMobile>
+        {isMobile && <SearchButton />}
+        <MoreMenu {...moreMenuProps} />
+      </BarRightOnMobile>
     </div>
   )
 }

--- a/src/modules/filelist/FileListHeaderMobile.jsx
+++ b/src/modules/filelist/FileListHeaderMobile.jsx
@@ -2,7 +2,6 @@ import cx from 'classnames'
 import React, { useState, useCallback } from 'react'
 import { useI18n } from 'twake-i18n'
 
-import { useSharingContext } from 'cozy-sharing'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ListIcon from 'cozy-ui/transpiled/react/Icons/List'
@@ -14,13 +13,10 @@ import {
 } from 'cozy-ui/transpiled/react/deprecated/Table'
 
 import MobileSortMenu from './MobileSortMenu'
-import ShareButton from '../drive/Toolbar/share/ShareButton'
 
 import styles from '@/styles/filelist.styl'
 
-import { ROOT_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
 import { useCurrentFolderId } from '@/hooks'
-import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
 const FileListHeaderMobile = ({
   canSort,
@@ -31,16 +27,8 @@ const FileListHeaderMobile = ({
 }) => {
   const { t } = useI18n()
   const [isShowingSortMenu, setIsShowingSortMenu] = useState(false)
-  const { isSelectionBarVisible } = useSelectionContext()
-  const { allLoaded } = useSharingContext()
 
   const folderId = useCurrentFolderId()
-  const showShareButton = Boolean(
-    folderId && folderId !== ROOT_DIR_ID && folderId !== TRASH_DIR_ID
-  )
-
-  const isDisabled = isSelectionBarVisible
-  const isSharingDisabled = isDisabled || !allLoaded
 
   const showSortMenu = useCallback(
     () => setIsShowingSortMenu(true),
@@ -79,16 +67,6 @@ const FileListHeaderMobile = ({
             onClose={hideSortMenu}
             onSort={(attr, order) => onFolderSort(folderId, attr, order)}
           />
-        )}
-        {showShareButton && (
-          <TableHeader
-            className={cx(
-              styles['fil-content-mobile-header'],
-              styles['fil-content-header--capitalize']
-            )}
-          >
-            <ShareButton isDisabled={isSharingDisabled} useShortLabel={true} />
-          </TableHeader>
         )}
         <TableHeader
           className={cx(


### PR DESCRIPTION
- Remove the share button from the toolbar
- Add the "more" menu to the cozy bar, where the share action will be available

<img width="334" height="244" alt="image" src="https://github.com/user-attachments/assets/310175fd-e7ff-4f8c-80d8-68027184ed86" />

https://www.notion.so/linagora/Mobile-drive-file-preview-screen-navigation-cleanup-context-menu-30b62718bad1801989dfc3abf4762918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the share button from the mobile file list header, simplifying the mobile interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->