### PR TITLE
feat: Add federated shared folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.14.1",
-    "cozy-sharing": "^28.3.0",
+    "cozy-sharing": "^28.4.0",
     "cozy-stack-client": "^60.19.0",
     "cozy-ui": "^135.8.0",
     "cozy-ui-plus": "^4.4.1",

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -20,3 +20,4 @@ export const MAX_PAYLOAD_SIZE = MAX_PAYLOAD_SIZE_IN_GB * 1024 * 1024 * 1024
 export const SHARING_TAB_ALL = 0
 export const SHARING_TAB_DRIVES = 1
 export const DEFAULT_UPLOAD_PROGRESS_HIDE_DELAY = 5000
+export const SHARINGS_VIEW_ROUTE = '/sharings'

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.spec.jsx
@@ -63,7 +63,7 @@ describe('useTransformFolderListHasSharedDriveShortcuts', () => {
       expect(result.current.sharedDrives).toHaveLength(1)
       expect(result.current.sharedDrives[0]).toMatchObject({
         _id: 'folder-1',
-        id: SHARED_DRIVES_DIR_ID,
+        id: 'folder-1',
         _type: 'io.cozy.files',
         type: 'directory',
         name: 'Shared Drive 1',

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
@@ -55,9 +55,10 @@ const useTransformFolderListHasSharedDriveShortcuts = (
             sharing.rules[0]?.title ?? ''
           ]
 
-          const fileInSharingSection = folderList?.find(
-            item =>
-              item.relationships?.referenced_by?.data?.[0]?.id === sharing.id
+          const fileInSharingSection = folderList?.find(item =>
+            item.relationships?.referenced_by?.data?.some(
+              ref => ref.id === sharing.id
+            )
           )
 
           if (fileInSharingSection && isOwner(fileInSharingSection.id ?? ''))
@@ -104,10 +105,13 @@ const useTransformFolderListHasSharedDriveShortcuts = (
   const nonSharedDriveList = useMemo(
     () =>
       folderList?.filter(item => {
-        const referencedById = item.relationships?.referenced_by?.data?.[0]?.id
+        const referencedByData = item.relationships?.referenced_by?.data ?? []
+        const isReferencedBySharedDrive = referencedByData.some(ref =>
+          sharedDriveIds.has(ref.id)
+        )
         return (
           item.dir_id !== SHARED_DRIVES_DIR_ID &&
-          !(referencedById && sharedDriveIds.has(referencedById)) &&
+          !isReferencedBySharedDrive &&
           (!showNextcloudFolder ? !isNextcloudShortcut(item) : true)
         )
       }) ?? [],

--- a/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
+++ b/src/hooks/useTransformFolderListHasSharedDriveShortcuts/index.tsx
@@ -73,7 +73,7 @@ const useTransformFolderListHasSharedDriveShortcuts = (
           return {
             ...fileInSharingSection,
             _id: rootFolderId,
-            id: SHARED_DRIVES_DIR_ID,
+            id: rootFolderId,
             _type: 'io.cozy.files' as const,
             path: `/Drives/${driveName}`,
             ...directoryData,

--- a/src/modules/filelist/helpers.ts
+++ b/src/modules/filelist/helpers.ts
@@ -5,13 +5,14 @@ import type { File } from '@/components/FolderPicker/types'
 import {
   TRASH_DIR_ID,
   ROOT_DIR_ID,
-  SHARED_DRIVES_DIR_ID
+  SHARED_DRIVES_DIR_ID,
+  SHARINGS_VIEW_ROUTE
 } from '@/constants/config'
 import { isNextcloudShortcut } from '@/modules/nextcloud/helpers'
 
 export const makeParentFolderPath = (file: File): string => {
   if (file.dir_id === SHARED_DRIVES_DIR_ID) {
-    return '/sharings'
+    return SHARINGS_VIEW_ROUTE
   }
 
   if (!file.path) return ''

--- a/src/modules/filelist/helpers.ts
+++ b/src/modules/filelist/helpers.ts
@@ -10,6 +10,8 @@ import {
 } from '@/constants/config'
 import { isNextcloudShortcut } from '@/modules/nextcloud/helpers'
 
+export const isDriveBackedFile = (file: File): boolean => !!file.driveId
+
 export const makeParentFolderPath = (file: File): string => {
   if (file.dir_id === SHARED_DRIVES_DIR_ID) {
     return SHARINGS_VIEW_ROUTE

--- a/src/modules/filelist/helpers.ts
+++ b/src/modules/filelist/helpers.ts
@@ -10,6 +10,10 @@ import {
 import { isNextcloudShortcut } from '@/modules/nextcloud/helpers'
 
 export const makeParentFolderPath = (file: File): string => {
+  if (file.dir_id === SHARED_DRIVES_DIR_ID) {
+    return '/sharings'
+  }
+
   if (!file.path) return ''
 
   return file.dir_id === ROOT_DIR_ID

--- a/src/modules/filelist/icons/FileIcon.jsx
+++ b/src/modules/filelist/icons/FileIcon.jsx
@@ -4,12 +4,13 @@ import FileImageLoader from 'cozy-ui-plus/dist/FileImageLoader'
 
 import styles from '@/styles/filelist.styl'
 
+import { isDriveBackedFile } from '@/modules/filelist/helpers'
 import FileIconMime from '@/modules/filelist/icons/FileIconMime'
 import FileIconShortcut from '@/modules/filelist/icons/FileIconShortcut'
 
 const FileIcon = ({ file, size, isEncrypted, viewType = 'list' }) => {
   const isImage = file.class === 'image'
-  const isShortcut = file.class === 'shortcut' && !file.driveId
+  const isShortcut = file.class === 'shortcut' && !isDriveBackedFile(file)
   if (isImage || file.class === 'pdf')
     return (
       <FileImageLoader

--- a/src/modules/filelist/icons/FileIcon.jsx
+++ b/src/modules/filelist/icons/FileIcon.jsx
@@ -9,7 +9,7 @@ import FileIconShortcut from '@/modules/filelist/icons/FileIconShortcut'
 
 const FileIcon = ({ file, size, isEncrypted, viewType = 'list' }) => {
   const isImage = file.class === 'image'
-  const isShortcut = file.class === 'shortcut'
+  const isShortcut = file.class === 'shortcut' && !file.driveId
   if (isImage || file.class === 'pdf')
     return (
       <FileImageLoader

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -22,7 +22,7 @@ import styles from '@/styles/filelist.styl'
 import type { File, FolderPickerEntry } from '@/components/FolderPicker/types'
 import { useViewSwitcherContext } from '@/lib/ViewSwitcherContext'
 import { DOCTYPE_KONNECTORS } from '@/lib/doctypes'
-import { isInfected } from '@/modules/filelist/helpers'
+import { isInfected, isDriveBackedFile } from '@/modules/filelist/helpers'
 import { BadgeKonnector } from '@/modules/filelist/icons/BadgeKonnector'
 import FileIcon from '@/modules/filelist/icons/FileIcon'
 import FileIconMime from '@/modules/filelist/icons/FileIconMime'
@@ -117,12 +117,13 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
   }
 
   const isSharingShortcut =
-    models.file.isSharingShortcut(file) && !isInSyncFromSharing && !file.driveId
-  const isRegularShortcut =
-    !isSharingShortcut &&
-    file.class === 'shortcut' &&
+    models.file.isSharingShortcut(file) &&
     !isInSyncFromSharing &&
-    !file.driveId
+    !isDriveBackedFile(file)
+  models.file.isSharingShortcut(file) && !isInSyncFromSharing && !file.driveId
+  const isRegularShortcut =
+    !isSharingShortcut && !isInSyncFromSharing && !isDriveBackedFile(file)
+  !isInSyncFromSharing && !file.driveId
   const isSimpleFile =
     !isSharingShortcut && !isRegularShortcut && !isInSyncFromSharing
   const isFolder = isSimpleFile && isDirectory(file)

--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { isReferencedBy, models } from 'cozy-client'
 import { isDirectory } from 'cozy-client/dist/models/file'
+import flag from 'cozy-flags'
 import { SharedBadge, SharingOwnerAvatar } from 'cozy-sharing'
 import Badge from 'cozy-ui/transpiled/react/Badge'
 import Box from 'cozy-ui/transpiled/react/Box'
@@ -85,8 +86,9 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
   }
 
   if (
-    file._id === 'io.cozy.files.shared-drives-dir' ||
-    isSharedDriveFolder(file)
+    flag('drive.shared-drive.enabled') &&
+    (file._id === 'io.cozy.files.shared-drives-dir' ||
+      isSharedDriveFolder(file))
   ) {
     return (
       <>
@@ -115,9 +117,12 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
   }
 
   const isSharingShortcut =
-    models.file.isSharingShortcut(file) && !isInSyncFromSharing
+    models.file.isSharingShortcut(file) && !isInSyncFromSharing && !file.driveId
   const isRegularShortcut =
-    !isSharingShortcut && file.class === 'shortcut' && !isInSyncFromSharing
+    !isSharingShortcut &&
+    file.class === 'shortcut' &&
+    !isInSyncFromSharing &&
+    !file.driveId
   const isSimpleFile =
     !isSharingShortcut && !isRegularShortcut && !isInSyncFromSharing
   const isFolder = isSimpleFile && isDirectory(file)

--- a/src/modules/filelist/virtualized/cells/FileNamePath.jsx
+++ b/src/modules/filelist/virtualized/cells/FileNamePath.jsx
@@ -9,7 +9,7 @@ import styles from '@/styles/filelist.styl'
 
 import CertificationsIcons from '@/modules/filelist/cells/CertificationsIcons.jsx'
 import { getFileNameAndExtension } from '@/modules/filelist/helpers'
-import { getFolderPath, getSharedDrivePath } from '@/modules/routeUtils'
+import { getFolderPath } from '@/modules/routeUtils'
 
 const FileNamePath = ({
   attributes,
@@ -45,10 +45,7 @@ const FileNamePath = ({
       </div>
     )
   }
-
-  const to = attributes.driveId
-    ? getSharedDrivePath(attributes.driveId, attributes.dir_id)
-    : getFolderPath(attributes.dir_id)
+  const to = attributes.driveId ? '/sharings' : getFolderPath(attributes.dir_id)
 
   return (
     <Link

--- a/src/modules/filelist/virtualized/cells/FileNamePath.jsx
+++ b/src/modules/filelist/virtualized/cells/FileNamePath.jsx
@@ -7,6 +7,7 @@ import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import styles from '@/styles/filelist.styl'
 
+import { SHARINGS_VIEW_ROUTE } from '@/constants/config'
 import CertificationsIcons from '@/modules/filelist/cells/CertificationsIcons.jsx'
 import { getFileNameAndExtension } from '@/modules/filelist/helpers'
 import { getFolderPath } from '@/modules/routeUtils'
@@ -45,7 +46,9 @@ const FileNamePath = ({
       </div>
     )
   }
-  const to = attributes.driveId ? '/sharings' : getFolderPath(attributes.dir_id)
+  const to = attributes.driveId
+    ? SHARINGS_VIEW_ROUTE
+    : getFolderPath(attributes.dir_id)
 
   return (
     <Link

--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -132,7 +132,8 @@ const AppRoute = () => (
         </>
       ) : null}
 
-      {flag('drive.shared-drive.enabled') ? (
+      {flag('drive.shared-drive.enabled') ||
+      flag('drive.federated-shared-folder.enabled') ? (
         <>
           <Route
             path="shareddrive/:driveId/:folderId"

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -86,6 +86,9 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   const [tab, setTab] = useState(tabParam)
 
   const isEnabledSharedDrive = flag('drive.shared-drive.enabled')
+  const isEnabledFederatedSharedFolder = flag(
+    'drive.federated-shared-folder.enabled'
+  )
 
   const extraColumnsNames = makeExtraColumnsNamesFromMedia({
     isMobile,
@@ -132,7 +135,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
   } = useTransformFolderListHasSharedDriveShortcuts(result.data)
 
   const filteredResult = useMemo(() => {
-    if (!isEnabledSharedDrive) {
+    if (!isEnabledSharedDrive && !isEnabledFederatedSharedFolder) {
       const filteredResultData =
         result.data?.filter(item => !(item.dir_id === SHARED_DRIVES_DIR_ID)) ||
         []
@@ -162,6 +165,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
     }
   }, [
     isEnabledSharedDrive,
+    isEnabledFederatedSharedFolder,
     tab,
     transformedSharedDrives,
     nonSharedDriveList,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5626,6 +5626,11 @@ cozy-device-helper@^4.0.1:
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-4.0.1.tgz#15dd904ff1e0d32fe0f735e0f08e818ddb4dcc03"
   integrity sha512-n6zs2M0nt8cKlpeOgSuqva1UjU93UwgefDYQWjA+j0Qa2K2zBes0X3yWjhDmOvWyu/sZChv4wshhVjojhwfo5A==
 
+cozy-device-helper@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-4.0.2.tgz#eaddb41b0df2be09a5af9663dba9dcf4033f8415"
+  integrity sha512-CrE6n9cBX8xGkLoMnrDHf+7TK4xKA73nFoehb2Df7MS5NdN4YhBGi4iYv2w+lShQPSPNkX+B47ZzQMznN3i/9w==
+
 cozy-devtools@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/cozy-devtools/-/cozy-devtools-1.2.1.tgz#680976ab69ebdf2d2727cffc07243705794d1a83"
@@ -5661,6 +5666,17 @@ cozy-doctypes@^1.98.2:
   version "1.98.2"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.98.2.tgz#77a7bd98c49bc611c31a88eeba47b1430b3b1b5d"
   integrity sha512-KJDzO4Pe00TXyZQoyUHXto5btVwWkYASaIK0ZQUIL/AFh4w4EqW/3AdLpxO3OviJ+rEcY/UxIdPrud0WVJRUaw==
+  dependencies:
+    cozy-logger "^1.17.0"
+    date-fns "^1.30.1"
+    es6-promise-pool "^2.5.0"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+
+cozy-doctypes@^1.98.3:
+  version "1.98.3"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.98.3.tgz#a1fa24e352aafd5a1962a8c848000605810d2a72"
+  integrity sha512-1IVp7DqaIjGw9HNb/kyh31J4/3NES+uua33v1GIWOEYgA8j63LJhMZvJTXgZUitym7dOYa900O4re2fua/3eIw==
   dependencies:
     cozy-logger "^1.17.0"
     date-fns "^1.30.1"
@@ -5874,15 +5890,15 @@ cozy-search@^0.14.1:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^28.3.0:
-  version "28.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.3.0.tgz#46eb42bda68890e431d346f30c9ac1f114f23588"
-  integrity sha512-OlPmum/fFQR61sEnSotzsfMTaMuM6bKIR1kw9eVE0mbeRb/hliGKJ8kEF7olAIqLIaNGbUXNrzQ0Dzg4Lx0peg==
+cozy-sharing@^28.4.0:
+  version "28.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.4.0.tgz#377b6edc57ab544e955f9800377e3e64b6a571e4"
+  integrity sha512-XxniwDH2oyx4i6nVmIkR7AiP3zcXAvkhFS0H2dTiB9g2GC+kJFtev4/Sg29iiQE6bYPq7rmVBMcQHOo5r/lBJQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"
-    cozy-device-helper "^4.0.1"
-    cozy-doctypes "^1.98.2"
+    cozy-device-helper "^4.0.2"
+    cozy-doctypes "^1.98.3"
     date-fns "2.30.0"
     lodash "^4.17.21"
     react-autosuggest "^10.1.0"


### PR DESCRIPTION
This allows to share an existing folder using the shared drives API.
The feature is gated behind the drive.federated-shared-folder.enabled flag.

[Capture vidéo du 2026-02-18 17-17-48.webm](https://github.com/user-attachments/assets/2b321632-d754-4435-a738-800faaa8d0ad)

<img width="596" height="81" alt="image" src="https://github.com/user-attachments/assets/ded16561-64c4-433c-900e-833c205438c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate files by excluding items referenced by shared drives from standard listings.
  * Refined shortcut handling so drive-backed shortcuts render via regular file rendering.
  * Ensure shared-drive items link to the central sharings path where applicable.

* **New Features**
  * Support federated shared folders alongside shared drives; shared-drive route shows when either feature is enabled.

* **Tests**
  * Added test verifying exclusion of shared-drive-referenced files.

* **Chores**
  * Bumped cozy-sharing dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->