### PR TITLE
fix: Regression on normal folder render

### DIFF
--- a/src/modules/filelist/icons/FileThumbnail.tsx
+++ b/src/modules/filelist/icons/FileThumbnail.tsx
@@ -120,10 +120,11 @@ const FileThumbnail: React.FC<FileThumbnailProps> = ({
     models.file.isSharingShortcut(file) &&
     !isInSyncFromSharing &&
     !isDriveBackedFile(file)
-  models.file.isSharingShortcut(file) && !isInSyncFromSharing && !file.driveId
   const isRegularShortcut =
-    !isSharingShortcut && !isInSyncFromSharing && !isDriveBackedFile(file)
-  !isInSyncFromSharing && !file.driveId
+    !isSharingShortcut &&
+    file.class === 'shortcut' &&
+    !isInSyncFromSharing &&
+    !isDriveBackedFile(file)
   const isSimpleFile =
     !isSharingShortcut && !isRegularShortcut && !isInSyncFromSharing
   const isFolder = isSimpleFile && isDirectory(file)


### PR DESCRIPTION
Before : 
<img width="282" height="266" alt="image" src="https://github.com/user-attachments/assets/af7b833f-a425-476a-aca6-6149a98d2dc9" />

After:
<img width="282" height="266" alt="image" src="https://github.com/user-attachments/assets/1964383b-aa90-46e4-9cdc-90c073dfda2e" />

Resulted from a wrong rebase conflict resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-type and shortcut detection accuracy for better file classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->