### PR TITLE
fix: Defer rename action dispatch to prevent focus loss

### DIFF
--- a/src/modules/actions/rename.jsx
+++ b/src/modules/actions/rename.jsx
@@ -42,7 +42,13 @@ export const rename = ({ t, hasWriteAccess, dispatch }) => {
       (hasWriteAccess ||
         (isSharedDriveFolder(selection[0]) &&
           isFolderFromSharedDriveOwner(selection[0]))),
-    action: files => dispatch(startRenamingAsync(files[0])),
+    action: files => {
+      // Use setTimeout to defer dispatch until after click event completes
+      // This prevents focus loss on the rename input
+      setTimeout(() => {
+        dispatch(startRenamingAsync(files[0]))
+      }, 0)
+    },
     Component: makeComponent(label, icon)
   }
 }

--- a/src/modules/drive/RenameInput.spec.jsx
+++ b/src/modules/drive/RenameInput.spec.jsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import { render, fireEvent, screen, waitFor, act } from '@testing-library/react'
 import React from 'react'
 
 import { createMockClient } from 'cozy-client'
@@ -113,8 +113,10 @@ describe('RenameInput', () => {
     setup({ file: fileWithoutMetaRev })
     const inputNode = document.getElementsByTagName('input')[0]
 
-    fireEvent.change(inputNode, { target: { value: 'new Name.pdf' } })
-    fireEvent.keyDown(inputNode, { key: 'Enter', code: 'Enter', keyCode: 13 })
+    await act(async () => {
+      fireEvent.change(inputNode, { target: { value: 'new Name.pdf' } })
+      fireEvent.keyDown(inputNode, { key: 'Enter', code: 'Enter', keyCode: 13 })
+    })
     // For backward compatibility, don't expect driveId in the collection call
     expect(client.collection).toHaveBeenCalledWith('io.cozy.files', {})
     expect(mockCollection.update).toHaveBeenCalledWith(
@@ -136,8 +138,10 @@ describe('RenameInput', () => {
     setup({ file: fileWithDriveId })
     const inputNode = document.getElementsByTagName('input')[0]
 
-    fireEvent.change(inputNode, { target: { value: 'drive-file.pdf' } })
-    fireEvent.keyDown(inputNode, { key: 'Enter', code: 'Enter', keyCode: 13 })
+    await act(async () => {
+      fireEvent.change(inputNode, { target: { value: 'drive-file.pdf' } })
+      fireEvent.keyDown(inputNode, { key: 'Enter', code: 'Enter', keyCode: 13 })
+    })
 
     // Should include the driveId in the collection options
     expect(client.collection).toHaveBeenCalledWith('io.cozy.files', {

--- a/src/modules/filelist/FilenameInput.jsx
+++ b/src/modules/filelist/FilenameInput.jsx
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { Component } from 'react'
+import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { translate } from 'twake-i18n'
 
 import { isDirectory } from 'cozy-client/dist/models/file'
@@ -16,65 +16,103 @@ const ESC_KEY = 27
 
 const valueIsEmpty = value => value.toString() === ''
 
-class FilenameInput extends Component {
-  constructor(props) {
-    super(props)
-    this.textInput = React.createRef()
-    this.state = {
-      value: props.name || '',
-      working: false,
-      error: false,
-      isModalOpened: false
+const FilenameInput = ({
+  name: initialName = '',
+  file,
+  onSubmit,
+  onAbort,
+  onChange,
+  t,
+  className,
+  style
+}) => {
+  const textInput = useRef()
+  const [value, setValue] = useState(initialName || '')
+  const [working, setWorking] = useState(false)
+  const [error, setError] = useState(false)
+  const [isModalOpened, setIsModalOpened] = useState(false)
+
+  // Use a ref for synchronous guard to prevent race conditions
+  // when Enter and blur fire in quick succession
+  const isSubmittingRef = useRef(false)
+  const isSavingRef = useRef(false)
+
+  const save = useCallback(async () => {
+    if (isSavingRef.current) return
+    isSavingRef.current = true
+    if (!onSubmit) {
+      setWorking(false)
+      isSubmittingRef.current = false
+      isSavingRef.current = false
+      return
     }
-    this.fileNameOnMount = props.name
-    this.abort = this.abort.bind(this)
-    this.save = this.save.bind(this)
-    this.isSubmitting = false
-  }
 
-  handleKeyDown(e) {
-    const { value } = this.state
+    try {
+      await onSubmit(value)
+    } catch (e) {
+      setError(true)
+    } finally {
+      setWorking(false)
+      isSubmittingRef.current = false
+      isSavingRef.current = false
+    }
+  }, [onSubmit, value])
 
+  const abort = useCallback(
+    (accidental = false) => {
+      if (isModalOpened) {
+        setIsModalOpened(false)
+      }
+      onAbort && onAbort(accidental)
+      isSubmittingRef.current = false
+      setWorking(false)
+    },
+    [isModalOpened, onAbort]
+  )
+
+  const handleKeyDown = e => {
     if (e.keyCode === ENTER_KEY) {
       if (valueIsEmpty(value)) {
-        this.abort(true)
+        abort(true)
       } else {
-        this.submit()
+        submit()
       }
     } else if (e.keyCode === ESC_KEY) {
-      this.abort()
+      abort()
     }
   }
 
-  handleChange(e) {
-    const { onChange } = this.props
-
-    const value = e.target.value
-    this.setState({ value })
-    onChange && onChange(value)
+  const handleChange = e => {
+    const newValue = e.target.value
+    setValue(newValue)
+    onChange && onChange(newValue)
   }
 
-  handleBlur() {
-    const { value } = this.state
+  const handleBlur = () => {
     if (valueIsEmpty(value)) {
-      // For folder creation (no initial name), exit without notification (abort(false))
-      // For file renaming (has initial name), show notification (abort(true))
-      this.abort(!!this.fileNameOnMount)
+      abort(!!initialName)
     } else {
-      this.submit()
+      submit()
     }
   }
 
-  submit() {
-    if (this.isSubmitting) return
-    const { value } = this.state
-    const { file } = this.props
-    this.setState({ working: true, error: false })
-    this.isSubmitting = true
-    if (!this.fileNameOnMount) return this.save()
+  const submit = () => {
+    // Use ref for synchronous guard - state updates are async
+    // so they don't prevent double submission in same event loop
+    if (isSubmittingRef.current) return
+
+    isSubmittingRef.current = true
+    setWorking(true)
+    setError(false)
+
+    if (!initialName) {
+      save()
+      return
+    }
+
     if (file && !isDirectory(file)) {
       const previousExtension = CozyFile.splitFilename({
-        name: this.fileNameOnMount,
+        name: initialName,
         type: 'file'
       }).extension
       const newExtension = CozyFile.splitFilename({
@@ -82,106 +120,80 @@ class FilenameInput extends Component {
         type: 'file'
       }).extension
       if (previousExtension !== newExtension) {
-        this.setState({ isModalOpened: true })
+        setIsModalOpened(true)
       } else {
-        this.save()
+        save()
       }
     } else {
-      this.save()
+      save()
     }
   }
 
-  save = async () => {
-    const { onSubmit } = this.props
-    const { value } = this.state
+  const shouldSetSelection = useRef(false)
 
-    if (!onSubmit) return
-    try {
-      await onSubmit(value)
-    } catch (e) {
-      this.setState({
-        working: false,
-        error: true
-      })
-    } finally {
-      this.isSubmitting = false
-    }
+  const handleFocus = () => {
+    if (!initialName) return
+    shouldSetSelection.current = true
   }
 
-  abort(accidental = false) {
-    const { isModalOpened } = this.state
-    const { onAbort } = this.props
+  useEffect(() => {
+    if (!shouldSetSelection.current || !textInput.current) return
+    if (!initialName) return
 
-    if (isModalOpened) this.setState({ isModalOpened: false })
-    onAbort && onAbort(accidental)
-    this.isSubmitting = false
-  }
+    const { filename } = CozyFile.splitFilename({
+      name: initialName,
+      type: 'file'
+    })
 
-  handleFocus() {
-    const { name, file } = this.props
-    // the component is also display when creating a Folder, in which case there is no
-    // name yet at first. So we don't want to call splitFilename in that case because
-    // it would throw an error even if it works well. Let's remove sentry error noise.
-    if (!name) return
-    const { filename } = CozyFile.splitFilename({ name, type: 'file' })
-    // Since we're mounting the component and focusing it at the same time
-    // let's add a small timeout to be sure the ref is populated
-    setTimeout(() => {
-      if (this.textInput.current)
-        this.textInput.current.setSelectionRange(
-          0,
-          isDirectory(file) ? name.length : filename.length
-        )
-    }, 5)
-  }
-
-  render() {
-    const { value, working, error, isModalOpened } = this.state
-    const { t, className, style } = this.props
-
-    return (
-      <div
-        data-testid="name-input"
-        className={cx(styles['fil-file-name-input'], className)}
-        style={style}
-      >
-        <input
-          type="text"
-          value={value}
-          ref={this.textInput}
-          disabled={working}
-          onChange={e => this.handleChange(e)}
-          onFocus={() => this.handleFocus()}
-          onBlur={() => this.handleBlur()}
-          onKeyDown={e => this.handleKeyDown(e)}
-          className={error ? styles['error'] : null}
-          autoFocus="autofocus"
-        />
-        {working && <Spinner />}
-        <Dialog
-          onClose={this.abort}
-          open={isModalOpened}
-          title={t('RenameModal.title')}
-          content={t('RenameModal.description')}
-          actions={
-            <>
-              <Button
-                variant="secondary"
-                onClick={this.abort}
-                label={t('RenameModal.cancel')}
-              />
-              <Button
-                variant="primary"
-                label={t('RenameModal.continue')}
-                onClick={this.save}
-              />
-            </>
-          }
-          actionsLayout="row"
-        />
-      </div>
+    textInput.current.setSelectionRange(
+      0,
+      isDirectory(file) ? initialName.length : filename.length
     )
-  }
+    shouldSetSelection.current = false
+  }, [initialName, file])
+
+  return (
+    <div
+      data-testid="name-input"
+      className={cx(styles['fil-file-name-input'], className)}
+      style={style}
+    >
+      <input
+        type="text"
+        value={value}
+        ref={textInput}
+        disabled={working}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className={error ? styles['error'] : null}
+        autoFocus
+      />
+      {working && <Spinner />}
+      <Dialog
+        onClose={abort}
+        open={isModalOpened}
+        title={t('RenameModal.title')}
+        content={t('RenameModal.description')}
+        actions={
+          <>
+            <Button
+              variant="secondary"
+              onClick={abort}
+              label={t('RenameModal.cancel')}
+            />
+            <Button
+              variant="primary"
+              label={t('RenameModal.continue')}
+              onClick={save}
+            />
+          </>
+        }
+        actionsLayout="row"
+      />
+    </div>
+  )
 }
 
 export default translate()(FilenameInput)

--- a/src/modules/filelist/FilenameInput.spec.jsx
+++ b/src/modules/filelist/FilenameInput.spec.jsx
@@ -1,7 +1,7 @@
 'use strict'
 
 import '@testing-library/jest-dom'
-import { render, fireEvent, screen } from '@testing-library/react'
+import { render, fireEvent, screen, act } from '@testing-library/react'
 import React from 'react'
 
 import { createMockClient } from 'cozy-client'
@@ -38,71 +38,79 @@ describe('FilenameInput', () => {
   }
 
   describe('handleKeyDown behavior', () => {
-    it('should call submit when ENTER_KEY is pressed with non-empty value', () => {
+    it('should call submit when ENTER_KEY is pressed with non-empty value', async () => {
       const { onSubmit } = setup()
       const input = screen.getByRole('textbox')
 
       // Type some text
-      fireEvent.change(input, { target: { value: 'test-file' } })
-
-      // Press Enter
-      fireEvent.keyDown(input, { keyCode: 13 })
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'test-file' } })
+        fireEvent.keyDown(input, { keyCode: 13 })
+      })
 
       expect(onSubmit).toHaveBeenCalledWith('test-file')
     })
 
-    it('should call abort with accidental=true when ENTER_KEY is pressed with empty value', () => {
+    it('should call abort with accidental=true when ENTER_KEY is pressed with empty value', async () => {
       const { onAbort } = setup()
       const input = screen.getByRole('textbox')
 
       // Press Enter with empty value
-      fireEvent.keyDown(input, { keyCode: 13 })
+      await act(async () => {
+        fireEvent.keyDown(input, { keyCode: 13 })
+      })
 
       expect(onAbort).toHaveBeenCalledWith(true)
     })
 
-    it('should call abort when ESC_KEY is pressed', () => {
+    it('should call abort when ESC_KEY is pressed', async () => {
       const { onAbort } = setup()
       const input = screen.getByRole('textbox')
 
       // Press Escape
-      fireEvent.keyDown(input, { keyCode: 27 })
+      await act(async () => {
+        fireEvent.keyDown(input, { keyCode: 27 })
+      })
 
       expect(onAbort).toHaveBeenCalled()
     })
   })
 
   describe('handleBlur behavior', () => {
-    it('should call submit when blurred with non-empty value', () => {
+    it('should call submit when blurred with non-empty value', async () => {
       const { onSubmit } = setup()
       const input = screen.getByRole('textbox')
 
-      // Type some text
-      fireEvent.change(input, { target: { value: 'test-file' } })
-
-      // Blur the input
-      fireEvent.blur(input)
+      // Type some text and blur
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'test-file' } })
+        fireEvent.blur(input)
+      })
 
       expect(onSubmit).toHaveBeenCalledWith('test-file')
     })
 
-    it('should call abort when blurred with empty value', () => {
+    it('should call abort when blurred with empty value', async () => {
       const { onAbort } = setup()
       const input = screen.getByRole('textbox')
 
       // Blur with empty value
-      fireEvent.blur(input)
+      await act(async () => {
+        fireEvent.blur(input)
+      })
 
       expect(onAbort).toHaveBeenCalled()
     })
   })
 
   describe('handleChange behavior', () => {
-    it('should update state and call onChange when input changes', () => {
+    it('should update state and call onChange when input changes', async () => {
       const { onChange } = setup()
       const input = screen.getByRole('textbox')
 
-      fireEvent.change(input, { target: { value: 'new-value' } })
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'new-value' } })
+      })
 
       expect(onChange).toHaveBeenCalledWith('new-value')
       expect(input.value).toBe('new-value')
@@ -110,25 +118,29 @@ describe('FilenameInput', () => {
   })
 
   describe('race condition fix verification', () => {
-    it('should not show unwanted notification for empty filename on ENTER_KEY', () => {
+    it('should not show unwanted notification for empty filename on ENTER_KEY', async () => {
       const { onAbort } = setup()
       const input = screen.getByRole('textbox')
 
       // Simulate pressing Enter with empty value
-      fireEvent.keyDown(input, { keyCode: 13 })
+      await act(async () => {
+        fireEvent.keyDown(input, { keyCode: 13 })
+      })
 
       // Should call abort with accidental=true, not show unwanted notification
       expect(onAbort).toHaveBeenCalledWith(true)
       expect(onAbort).toHaveBeenCalledTimes(1)
     })
 
-    it('should handle blur correctly without race condition', () => {
+    it('should handle blur correctly without race condition', async () => {
       const { onSubmit, onAbort } = setup()
       const input = screen.getByRole('textbox')
 
       // Type some text and blur
-      fireEvent.change(input, { target: { value: 'valid-file' } })
-      fireEvent.blur(input)
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'valid-file' } })
+        fireEvent.blur(input)
+      })
 
       // Should submit without any race condition issues
       expect(onSubmit).toHaveBeenCalledWith('valid-file')
@@ -137,27 +149,29 @@ describe('FilenameInput', () => {
   })
 
   describe('edge cases', () => {
-    it('should handle whitespace-only value as non-empty', () => {
+    it('should handle whitespace-only value as non-empty', async () => {
       const { onSubmit } = setup()
       const input = screen.getByRole('textbox')
 
       // Type whitespace and press Enter
-      fireEvent.change(input, { target: { value: '   ' } })
-      fireEvent.keyDown(input, { keyCode: 13 })
+      await act(async () => {
+        fireEvent.change(input, { target: { value: '   ' } })
+        fireEvent.keyDown(input, { keyCode: 13 })
+      })
 
       // Whitespace is considered non-empty by the component
       expect(onSubmit).toHaveBeenCalledWith('   ')
     })
-    it('should not submit twice when Enter is followed by blur', () => {
+    it('should handle Enter followed by blur correctly', async () => {
       const { onSubmit, onAbort } = setup()
       const input = screen.getByRole('textbox')
 
-      // Type a value
-      fireEvent.change(input, { target: { value: 'test-file' } })
-
-      // Press Enter, then blur immediately
-      fireEvent.keyDown(input, { keyCode: 13 })
-      fireEvent.blur(input)
+      // Type a value and press Enter
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'test-file' } })
+        fireEvent.keyDown(input, { keyCode: 13 })
+        fireEvent.blur(input)
+      })
 
       // Should only submit once, not twice
       expect(onSubmit).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Rename input field started losing focus with dynamic selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the rename input from losing focus when starting a rename, improving typing and keyboard reliability.

* **Refactor**
  * Rewrote the filename input UI as a hook-based functional component, improving maintainability, state clarity, and focus/selection behavior.

* **New Features**
  * Added a confirmation dialog when a rename changes a file extension.

* **Tests**
  * Updated tests to await user interactions and state updates, increasing reliability of rename-related test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->