### PR TITLE
fix: Remove favorite and personalize for shared drive recipient

### DIFF
--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -102,15 +102,17 @@ const MoreMenu = ({
                 displayedFolder={displayedFolder}
                 hasWriteAccess={hasWriteAccess}
               />
-              <PersonalizeFolderItem
-                displayedFolder={displayedFolder}
-                hasWriteAccess={hasWriteAccess}
-              />
+              {!isSharedDriveRecipient && (
+                <PersonalizeFolderItem
+                  displayedFolder={displayedFolder}
+                  hasWriteAccess={hasWriteAccess}
+                />
+              )}
             </InsideRegularFolder>
             {isMobile && hasWriteAccess && <AddMenuItem />}
             <SelectableItem onClick={showSelectionBar} />
             {isSharedDriveOwner && <ManageAccessItem />}
-            {hasWriteAccess && (
+            {hasWriteAccess && !isSharedDriveRecipient && (
               <InsideRegularFolder
                 displayedFolder={displayedFolder}
                 folderId={folderId}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Personalize Folder and Favorites menu options are now hidden when accessing shared drives as a recipient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->