### PR TITLE
fix: Separate shared drive and federated shared folder in interface

### DIFF
--- a/src/modules/shareddrives/helpers.ts
+++ b/src/modules/shareddrives/helpers.ts
@@ -57,3 +57,23 @@ export const isSharedDriveFolder = (
     file.type === 'directory'
   )
 }
+
+export const isSharedDrive = (
+  sharedDrive: SharedDrive,
+  sharedDriveDirId: string
+): boolean => {
+  try {
+    const parentId = sharedDrive.rules[0].values[0]
+
+    return parentId === sharedDriveDirId
+  } catch {
+    return false
+  }
+}
+
+export const isFederatedSharedFolder = (
+  sharedDrive: SharedDrive,
+  sharedDriveDirId: string
+): boolean => {
+  return !isSharedDrive(sharedDrive, sharedDriveDirId)
+}

--- a/src/modules/shareddrives/hooks/useSharedDrives.js
+++ b/src/modules/shareddrives/hooks/useSharedDrives.js
@@ -4,6 +4,7 @@ import { useClient, useQuery } from 'cozy-client'
 
 import { DEFAULT_SORT } from '@/config/sort'
 import { SHARED_DRIVES_DIR_ID } from '@/constants/config'
+import { isSharedDrive } from '@/modules/shareddrives/helpers'
 import { buildDriveQuery } from '@/queries'
 
 export const useSharedDrives = () => {
@@ -18,7 +19,13 @@ export const useSharedDrives = () => {
     sortAttribute: DEFAULT_SORT.attribute,
     sortOrder: DEFAULT_SORT.order
   })
-  const { lastUpdate } = useQuery(folderQuery.definition, folderQuery.options)
+
+  const { data: sharedDrivesDir, lastUpdate } = useQuery(
+    folderQuery.definition,
+    folderQuery.options
+  )
+
+  const sharedDrivesDirId = sharedDrivesDir && sharedDrivesDir[0]._id
 
   useEffect(() => {
     let isCancelled = false
@@ -31,7 +38,11 @@ export const useSharedDrives = () => {
           .fetchSharedDrives()
 
         if (!isCancelled) {
-          setSharedDrives(sharedDrives)
+          const filteredSharedDrives = sharedDrives.filter(sharedDrive =>
+            isSharedDrive(sharedDrive, sharedDrivesDirId)
+          )
+
+          setSharedDrives(filteredSharedDrives)
         }
       } finally {
         if (!isCancelled) {
@@ -46,7 +57,7 @@ export const useSharedDrives = () => {
     return () => {
       isCancelled = true
     }
-  }, [client, lastUpdate])
+  }, [client, sharedDrivesDirId, lastUpdate])
 
   return { isLoading, isLoaded, sharedDrives }
 }


### PR DESCRIPTION
useSharedDrives not return only true shared drives, so not federated shared folder that are shared drives which are not in the SHARED_DRIVES_DIR folder.

Fix sidebar and sharing tab interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shared drive identification and filtering capabilities to help you better organize and manage your shared storage resources.
  * Enhanced ability to more accurately distinguish between different shared drives and federated shared folders in your system.
  * Better categorization of shared storage to provide improved visibility and control over all your resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->