### PR TITLE
Fix different shared drive actions

### DIFF
--- a/src/modules/actions/components/personalizeFolder.js
+++ b/src/modules/actions/components/personalizeFolder.js
@@ -25,7 +25,8 @@ const personalizeFolder = ({
       flag('drive.folder-personalization.enabled') &&
       hasWriteAccess &&
       docs.length === 1 &&
-      docs[0].type === 'directory',
+      docs[0].type === 'directory' &&
+      !driveId,
     action: docs => {
       if (docs.length === 1 && docs[0].type === 'directory') {
         const folderId = docs[0]._id

--- a/src/modules/actions/download.jsx
+++ b/src/modules/actions/download.jsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react'
 
+import { isDirectory } from 'cozy-client/dist/models/file'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download'
@@ -44,6 +45,14 @@ export const download = ({
     icon,
     allowInfectedFiles: false,
     displayCondition: files => {
+      // We cannot download folders or multiple files in shared drives
+      if (
+        driveId &&
+        (files.length > 1 || (files.length === 1 && isDirectory(files[0])))
+      ) {
+        return false
+      }
+
       // We cannot generate archive for encrypted files, for now.
       // Then, we do not display the download button when the selection
       // includes an encrypted folder or several encrypted files

--- a/src/modules/actions/rename.jsx
+++ b/src/modules/actions/rename.jsx
@@ -6,11 +6,6 @@ import RenameIcon from 'cozy-ui/transpiled/react/Icons/Rename'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
-import {
-  isFolderFromSharedDriveOwner,
-  isSharedDriveFolder
-} from '../shareddrives/helpers'
-
 import { startRenamingAsync } from '@/modules/drive/rename'
 
 const makeComponent = (label, icon) => {
@@ -29,7 +24,12 @@ const makeComponent = (label, icon) => {
   return Component
 }
 
-export const rename = ({ t, hasWriteAccess, dispatch }) => {
+export const rename = ({
+  t,
+  hasWriteAccess,
+  dispatch,
+  shouldHideIfSharedDriveRecipient
+}) => {
   const label = t('SelectionBar.rename')
   const icon = RenameIcon
 
@@ -37,11 +37,13 @@ export const rename = ({ t, hasWriteAccess, dispatch }) => {
     name: 'rename',
     label,
     icon,
-    displayCondition: selection =>
-      selection.length === 1 &&
-      (hasWriteAccess ||
-        (isSharedDriveFolder(selection[0]) &&
-          isFolderFromSharedDriveOwner(selection[0]))),
+    displayCondition: selection => {
+      // special case for rename in sharings tab
+      const isAllowedForSharedDrive = shouldHideIfSharedDriveRecipient
+        ? !selection[0].driveId
+        : true
+      return selection.length === 1 && hasWriteAccess && isAllowedForSharedDrive
+    },
     action: files => {
       // Use setTimeout to defer dispatch until after click event completes
       // This prevents focus loss on the rename input

--- a/src/modules/drive/Toolbar/index.jsx
+++ b/src/modules/drive/Toolbar/index.jsx
@@ -122,9 +122,15 @@ const ToolbarWithSharingContext = props => {
     <SharedDocument docId={folderId} driveId={driveId}>
       {sharingProps => {
         const { hasWriteAccess, isSharedWithMe } = sharingProps
+        // We do not want to enable write access actions for recipient for shared drive root folder.
+        // To check if it is shared drive root folder, we check if the document is shared because
+        // in a shared drive only the share drive root folder has a sharing
+        const hasWriteAccessExceptSharedDriveRootFolder = driveId
+          ? hasWriteAccess && !isSharedWithMe
+          : hasWriteAccess
         return (
           <Toolbar
-            hasWriteAccess={hasWriteAccess}
+            hasWriteAccess={hasWriteAccessExceptSharedDriveRootFolder}
             isSharedWithMe={isSharedWithMe}
             folderId={folderId}
             {...props}

--- a/src/modules/drive/Toolbar/move/MoveItem.jsx
+++ b/src/modules/drive/Toolbar/move/MoveItem.jsx
@@ -10,7 +10,6 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { navigateToModalWithMultipleFile } from '@/modules/actions/helpers'
-import { isSharedDriveFolder } from '@/modules/shareddrives/helpers'
 
 const MoveItem = ({ displayedFolder, hasWriteAccess }) => {
   const { t } = useI18n()
@@ -18,7 +17,7 @@ const MoveItem = ({ displayedFolder, hasWriteAccess }) => {
   const { pathname, search } = useLocation()
   const { isMobile } = useBreakpoints()
 
-  if (!hasWriteAccess || isSharedDriveFolder(displayedFolder)) {
+  if (!hasWriteAccess) {
     return null
   }
 

--- a/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
+++ b/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
@@ -54,7 +54,7 @@ const SharedDriveFolderBody = ({
     hasWriteAccess: canWriteToCurrentFolder,
     byDocId,
     dispatch,
-    canMove: true,
+    canMove: canWriteToCurrentFolder,
     navigate,
     showAlert,
     pushModal,

--- a/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
+++ b/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
@@ -21,7 +21,6 @@ import {
   summariseByAI
 } from '@/modules/actions'
 import { moveTo } from '@/modules/actions/components/moveTo'
-import { personalizeFolder } from '@/modules/actions/components/personalizeFolder'
 import { FolderBody } from '@/modules/folder/components/FolderBody'
 
 const SharedDriveFolderBody = ({
@@ -69,7 +68,6 @@ const SharedDriveFolderBody = ({
       hr,
       rename,
       moveTo,
-      personalizeFolder,
       infos,
       hr,
       versions,

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -98,7 +98,6 @@ const SharedDriveFolderView = () => {
     popModal,
     refresh
   })
-
   const actionsOptions = useMemo(
     () => ({
       client,
@@ -111,7 +110,7 @@ const SharedDriveFolderView = () => {
       hasWriteAccess: canWriteToCurrentFolder,
       byDocId,
       dispatch,
-      canMove: true,
+      canMove: canWriteToCurrentFolder,
       navigate,
       showAlert,
       pushModal,

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -197,6 +197,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
     hasWriteAccess: true,
     canMove: true,
     isPublic: false,
+    shouldHideIfSharedDriveRecipient: true,
     allLoaded,
     showAlert,
     isMobile,


### PR DESCRIPTION
Different actions for shared drive files or folders were not possible or broken. Fixed them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission restrictions for shared drive operations: download now correctly prevents multi-file and folder downloads in shared drives.
  * Corrected write access checks for move operations, now properly enforcing permissions based on current folder access.

* **Refactor**
  * Improved rename action visibility logic for shared drive recipients with stricter permission validation.
  * Enhanced personalization action gating in specific contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->