### PR TITLE
Fix creating new folder when current folder is empty

### DIFF
--- a/src/modules/drive/Toolbar/components/AddEncryptedFolderItem.jsx
+++ b/src/modules/drive/Toolbar/components/AddEncryptedFolderItem.jsx
@@ -52,8 +52,10 @@ const AddEncryptedFolderItem = ({
 const mapDispatchToProps = dispatch => ({
   // An encrypted folder triggers a new encryption key generation
   addEncryptedFolder: () => {
-    dispatch(encryptedFolder())
-    dispatch(showNewFolderInput())
+    setTimeout(() => {
+      dispatch(encryptedFolder())
+      dispatch(showNewFolderInput())
+    }, 0)
   }
 })
 

--- a/src/modules/drive/Toolbar/components/AddFolderItem.jsx
+++ b/src/modules/drive/Toolbar/components/AddFolderItem.jsx
@@ -42,7 +42,10 @@ const AddFolderItem = ({ addFolder, onClick, isReadOnly }) => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  addFolder: () => dispatch(showNewFolderInput())
+  addFolder: () =>
+    setTimeout(() => {
+      dispatch(showNewFolderInput())
+    }, 0)
 })
 
 export default connect(null, mapDispatchToProps)(AddFolderItem)


### PR DESCRIPTION
I did not understand better what happened BUT it started with React 18 update. Follows https://github.com/linagora/twake-drive/pull/3716.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deferred folder-creation actions to the next event loop tick, improving UI timing and responsiveness when adding new (including encrypted) folders and reducing race-condition related glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->