### PR TITLE
feat: Deselect when click anywhere on drive application

### DIFF
--- a/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
@@ -59,7 +59,8 @@ const FolderViewBodyContent = ({
 
   const navigate = useNavigate()
 
-  const { selectAll, selectedItems } = useSelectionContext()
+  const { selectAll, selectedItems, setSelectedItems, setIsSelectAll } =
+    useSelectionContext()
   const { sharedPaths } = useSharingContext()
   const { registerCancelable } = useCancelable()
   const { showAlert } = useAlert()
@@ -108,6 +109,18 @@ const FolderViewBodyContent = ({
   }, [navigate])
 
   const isDynamicSelectionEnabled = flag('drive.dynamic-selection.enabled')
+
+  const handleContainerClick = useCallback(
+    e => {
+      const target = e.target
+      const isOnFile = target.closest('[data-file-id]')
+      if (isOnFile) return
+
+      setSelectedItems({})
+      setIsSelectAll(false)
+    },
+    [setSelectedItems, setIsSelectAll]
+  )
 
   const dragProps = useMemo(
     () => ({
@@ -196,7 +209,9 @@ const FolderViewBodyContent = ({
             {viewContent}
           </RectangularSelection>
         ) : (
-          viewContent
+          <div onClick={handleContainerClick} className="u-h-100">
+            {viewContent}
+          </div>
         )}
       </div>
     </FolderUnlocker>


### PR DESCRIPTION
[Capture vidéo du 2026-03-13 17-28-00.webm](https://github.com/user-attachments/assets/09ee8449-53fb-4512-a2ad-aaa6c159a5ce)

https://www.notion.so/linagora/Dynamic-selection-fixes-2fd62718bad180809010e3f9eae9d0c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File selection in folder view now clears when you click outside file items, providing more intuitive selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->