### PR TITLE
Small shared folder fixes

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,7 +41,7 @@
   },
   "toolbar": {
     "menu_manage_access": "Manage access",
-    "menu_leave_shared_drive": "Leave drive",
+    "menu_leave_shared_drive": "Leave shared folder",
     "menu_upload": "Upload files",
     "item_more": "More",
     "menu_new_folder": "Folder",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -41,7 +41,7 @@
   },
   "toolbar": {
     "menu_manage_access": "Gérer les accès",
-    "menu_leave_shared_drive": "Sortir drive",
+    "menu_leave_shared_drive": "Quitter le partage",
     "menu_upload": "Importer des fichiers",
     "item_more": "Plus",
     "menu_new_folder": "Dossier",

--- a/src/modules/actions/download.jsx
+++ b/src/modules/actions/download.jsx
@@ -10,6 +10,7 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { downloadFiles } from './utils'
 
 import { isEncryptedFolder, isEncryptedFile } from '@/lib/encryption'
+import { isFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
 
 const makeComponent = (label, icon) => {
   const Component = forwardRef((props, ref) => {
@@ -45,11 +46,26 @@ export const download = ({
     icon,
     allowInfectedFiles: false,
     displayCondition: files => {
-      // We cannot download folders or multiple files in shared drives
+      // # We cannot download folders or multiple files in shared drives
+
+      // ## For sharing tab
       if (
         driveId &&
         (files.length > 1 || (files.length === 1 && isDirectory(files[0])))
       ) {
+        return false
+      }
+
+      // ## For shared drive view
+      const isSingleSharedDriveFolder =
+        files.length === 1 &&
+        isFromSharedDriveRecipient(files[0]) &&
+        isDirectory(files[0])
+
+      const hasMultipleFilesIncludeShareDriveFiles =
+        files.length > 1 && files.some(file => isFromSharedDriveRecipient(file))
+
+      if (isSingleSharedDriveFolder || hasMultipleFilesIncludeShareDriveFiles) {
         return false
       }
 

--- a/src/modules/actions/share.jsx
+++ b/src/modules/actions/share.jsx
@@ -10,8 +10,16 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { isEncryptedFileOrFolder } from '@/lib/encryption'
 import { navigateToModal } from '@/modules/actions/helpers'
+import { isFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
 
-const share = ({ t, hasWriteAccess, navigate, pathname, allLoaded }) => {
+const share = ({
+  t,
+  shouldHideIfSharedDriveRecipient,
+  hasWriteAccess,
+  navigate,
+  pathname,
+  allLoaded
+}) => {
   const label = t('Files.share.cta')
   const icon = ShareIcon
 
@@ -21,6 +29,15 @@ const share = ({ t, hasWriteAccess, navigate, pathname, allLoaded }) => {
     icon,
     allowInfectedFiles: false,
     displayCondition: files => {
+      // Not this sharing action in sharings tab
+      if (
+        shouldHideIfSharedDriveRecipient &&
+        files?.length === 1 &&
+        isFromSharedDriveRecipient(files[0])
+      ) {
+        return false
+      }
+
       return (
         allLoaded && // We need to wait for the sharing context to be completely loaded to avoid race conditions
         hasWriteAccess &&

--- a/src/modules/shareddrives/components/actions/leaveSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/leaveSharedDrive.js
@@ -1,0 +1,46 @@
+import React, { forwardRef } from 'react'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import LogoutIcon from 'cozy-ui/transpiled/react/Icons/Logout'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+import { isFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
+
+// Only for sharing tabs
+export const leaveSharedDrive = ({ client, showAlert, t }) => {
+  const label = t('toolbar.menu_leave_shared_drive')
+  const icon = LogoutIcon
+
+  return {
+    name: 'leaveSharedDrive',
+    label: label,
+    icon,
+    displayCondition: docs => {
+      return docs.length === 1 && isFromSharedDriveRecipient(docs[0])
+    },
+    action: async docs => {
+      const sharedDriveId = docs[0].driveId
+
+      await client
+        .collection('io.cozy.sharings')
+        .revokeSelf({ _id: sharedDriveId })
+
+      showAlert({
+        message: t('Files.share.revokeSelf.success'),
+        severity: 'success'
+      })
+    },
+    Component: forwardRef(function deleteSharedDrive(props, ref) {
+      return (
+        <ActionsMenuItem {...props} ref={ref}>
+          <ListItemIcon>
+            <Icon icon={icon} className="u-error" />
+          </ListItemIcon>
+          <ListItemText primary={label} className="u-error" />
+        </ActionsMenuItem>
+      )
+    })
+  }
+}

--- a/src/modules/shareddrives/components/actions/shareSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.js
@@ -1,0 +1,46 @@
+import React, { forwardRef } from 'react'
+
+import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
+import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+
+import { navigateToModal } from '@/modules/actions/helpers'
+import { isFromSharedDriveRecipient } from '@/modules/shareddrives/helpers'
+
+// Only for sharing tabs
+export const shareSharedDrive = ({ navigate, t }) => {
+  const label = t('Files.share.cta')
+  const icon = ShareIcon
+
+  return {
+    name: 'shareSharedDrive',
+    label: label,
+    icon,
+    displayCondition: docs => {
+      return docs.length === 1 && isFromSharedDriveRecipient(docs[0])
+    },
+    action: docs => {
+      const folderId = docs[0]._id
+      const driveId = docs[0].driveId
+
+      navigateToModal({
+        navigate,
+        pathname: `/shareddrive/${driveId}/${folderId}`,
+        files: docs,
+        path: 'share'
+      })
+    },
+    Component: forwardRef(function ShareSharedDrive(props, ref) {
+      return (
+        <ActionsMenuItem {...props} ref={ref}>
+          <ListItemIcon>
+            <Icon icon={icon} />
+          </ListItemIcon>
+          <ListItemText primary={label} />
+        </ActionsMenuItem>
+      )
+    })
+  }
+}

--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -52,6 +52,8 @@ import FabWithAddMenuContext from '@/modules/drive/FabWithAddMenuContext'
 import Toolbar from '@/modules/drive/Toolbar'
 import FileListRowsPlaceholder from '@/modules/filelist/FileListRowsPlaceholder'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
+import { leaveSharedDrive } from '@/modules/shareddrives/components/actions/leaveSharedDrive'
+import { shareSharedDrive } from '@/modules/shareddrives/components/actions/shareSharedDrive'
 import {
   buildSharingsQuery,
   buildSharingsWithMetadataAttributeQuery
@@ -205,6 +207,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
       selectAllItems,
       share,
       shareNative,
+      shareSharedDrive,
       download,
       hr,
       summariseByAI,
@@ -213,6 +216,7 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
       moveTo,
       addToFavorites,
       removeFromFavorites,
+      leaveSharedDrive,
       infos,
       hr,
       versions

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -559,7 +559,8 @@ export const buildFavoritesQuery: QueryBuilder<buildFavoritesQueryParams> = ({
       .partialIndex({
         'cozyMetadata.favorite': true,
         path: { $or: [{ $exists: false }, { $regex: '^(?!/.cozy_trash)' }] },
-        trashed: { $or: [{ $exists: false }, { $eq: false }] }
+        trashed: { $or: [{ $exists: false }, { $eq: false }] },
+        driveId: { $exists: false }
       })
       .indexFields([sortAttribute])
       .sortBy([{ [sortAttribute]: sortOrder }]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a contextual "Share" action for single shared-drive items and a "Leave shared folder" action in the Sharings view.

- **Bug Fixes**
  - Download disabled for a single shared-drive folder or when multiple selected items include shared-drive files.
  - Favorites view now excludes items from shared drives.

- **Style**
  - Updated English label to “Leave shared folder” and French to “Quitter le partage.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->