### PR TITLE
feat: Now cancel the previous selection on click on a file

### DIFF
--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -26,6 +26,12 @@ export const handleClick = ({
   // simply remove this "if" the flag is not necessary anymore
   if (!flag('drive.doubleclick.enabled')) {
     if (selectionModeActive) {
+      if (flag('drive.dynamic-selection.enabled') && !event.shiftKey) {
+        event.stopPropagation()
+        setSelectedItems({ [file._id]: file })
+        onInteractWithFile?.(file._id, event)
+        return
+      }
       return toggle(event)
     } else {
       return openLink(event)

--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -78,7 +78,7 @@ const Table = forwardRef(
     },
     ref
   ) => {
-    const { toggleSelectedItem } = useSelectionContext()
+    const { toggleSelectedItem, setSelectedItems } = useSelectionContext()
     const { isNew } = useNewItemHighlightContext()
     const internalVirtuosoRef = useRef(null)
     const virtuosoRef = parentVirtuosoRef || internalVirtuosoRef
@@ -86,13 +86,27 @@ const Table = forwardRef(
 
     const { sortOrder, setOrder } = orderProps
 
+    const selectedItemsCount = Object.keys(selectedItems || {}).length
     const handleRowSelect = useCallback(
       (row, event) => {
         event?.stopPropagation?.()
-        toggleSelectedItem(row)
+        if (
+          flag('drive.dynamic-selection.enabled') &&
+          selectedItemsCount > 0 &&
+          !event?.shiftKey
+        ) {
+          setSelectedItems({ [row._id]: row })
+        } else {
+          toggleSelectedItem(row)
+        }
         onInteractWithFile?.(row?._id, event)
       },
-      [toggleSelectedItem, onInteractWithFile]
+      [
+        toggleSelectedItem,
+        onInteractWithFile,
+        selectedItemsCount,
+        setSelectedItems
+      ]
     )
 
     const handleSort = ({ order, orderBy }) => {


### PR DESCRIPTION
Only when dynamic selection is activated
This more like any drive behavior

[Capture vidéo du 2026-03-17 07-49-21.webm](https://github.com/user-attachments/assets/4ecfb645-e4dc-4cd8-ae3d-3411910b7b82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced folder selection: when dynamic selection is enabled, single clicks replace the current selection (instead of toggling) while modifier-key multi-selection still works.
  * Single-click interactions now immediately register with the file view, improving responsiveness when dynamic selection is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->