### PR TITLE
fix: Proper interaction between shift select and rectangle selection

### DIFF
--- a/src/modules/selection/RectangularSelection.jsx
+++ b/src/modules/selection/RectangularSelection.jsx
@@ -24,7 +24,8 @@ const RectangularSelection = ({
   children,
   items,
   scrollContainerRef,
-  scrollElement
+  scrollElement,
+  onSelectEnd
 }) => {
   const containerRef = useRef(null)
   const selectoRef = useRef(null)
@@ -86,22 +87,29 @@ const RectangularSelection = ({
       const isMultiSelect = e.inputEvent?.ctrlKey || e.inputEvent?.metaKey
       const newSelection = isMultiSelect ? { ...selectedItems } : {}
 
+      let lastSelectedId = null
       for (const el of e.selected) {
         const file = getFileFromElement(el)
         if (file && !newSelection[file._id]) {
           newSelection[file._id] = file
+          lastSelectedId = file._id
         }
       }
 
       setSelectedItems(newSelection)
       setIsSelectAll(Object.keys(newSelection).length === items.length)
+
+      if (lastSelectedId) {
+        onSelectEnd?.(lastSelectedId)
+      }
     },
     [
       items.length,
       selectedItems,
       getFileFromElement,
       setSelectedItems,
-      setIsSelectAll
+      setIsSelectAll,
+      onSelectEnd
     ]
   )
 

--- a/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
+++ b/src/modules/views/Folder/virtualized/FolderViewBodyContent.jsx
@@ -205,6 +205,7 @@ const FolderViewBodyContent = ({
             items={sortedRows}
             scrollContainerRef={folderViewRef}
             scrollElement={scrollElement}
+            onSelectEnd={setLastInteractedItem}
           >
             {viewContent}
           </RectangularSelection>


### PR DESCRIPTION
Now the rectangle selection set the last interactive item to allow a proper extend of selection when rectangle selection is done first and then the selection is extended with shift+click

[Capture vidéo du 2026-03-17 09-50-39.webm](https://github.com/user-attachments/assets/ff5cf3ce-4663-4a99-9b56-73fe091069ed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Selection interactions in folder views now include enhanced tracking of the most recently selected items during bulk selection operations. The rectangular selection mechanism has been strengthened to maintain awareness of the last interacted item, providing better contextual understanding of user selection patterns and improving the overall interaction workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->