### PR TITLE
fix: Remove "Shared" label in grid

### DIFF
--- a/src/modules/filelist/cells/FileName.jsx
+++ b/src/modules/filelist/cells/FileName.jsx
@@ -4,8 +4,6 @@ import { Link } from 'react-router-dom'
 import { useI18n } from 'twake-i18n'
 
 import { isDirectory } from 'cozy-client/dist/models/file'
-import Icon from 'cozy-ui/transpiled/react/Icon'
-import ShareIcon from 'cozy-ui/transpiled/react/Icons/Share'
 import MidEllipsis from 'cozy-ui/transpiled/react/MidEllipsis'
 import { TableCell } from 'cozy-ui/transpiled/react/deprecated/Table'
 
@@ -97,16 +95,6 @@ const FileName = ({
                 {isMobile && <CertificationsIcons attributes={attributes} />}
               </div>
             ))}
-          {!withFilePath && (
-            <div className={styles['fil-file-shared']}>
-              <Icon
-                icon={ShareIcon}
-                size="10"
-                className={styles['fil-file-shared-icon']}
-              />
-              {t('Files.share.shared')}
-            </div>
-          )}
         </div>
       )}
     </TableCell>


### PR DESCRIPTION
This shared remains from enterprise shared drive feature cleaning. Since this label was added only for this feature at first (and it is now always visible in grid view) I think we should remove it

https://www.notion.so/linagora/Do-not-display-Shared-line-below-folders-32662718bad18011be22c638eb1267ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the shared-file indicator from the file list display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->