### PR TITLE
feat: Set hover style for new uploaded items

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "cozy-search": "^0.14.1",
     "cozy-sharing": "^28.11.1",
     "cozy-stack-client": "^60.23.0",
-    "cozy-ui": "^136.2.2",
+    "cozy-ui": "^136.3.0",
     "cozy-ui-plus": "^4.4.1",
     "cozy-viewer": "^26.6.4",
     "date-fns": "2.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6243,10 +6243,10 @@ cozy-ui-plus@^4.4.1:
     react-final-form-arrays "3.1.4"
     rooks "7.14.1"
 
-cozy-ui@^136.2.2:
-  version "136.2.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-136.2.2.tgz#39abd89571d686788ce7b008fbadf7d19f7bb08c"
-  integrity sha512-FvJWXFeO1oYFccbpyQkHwepd9Bu6Iv7sgpjnzt1ciiIOyjunRmdMDpgyjSajauH7hwE+oAiUp0KetPB0BcJPmQ==
+cozy-ui@^136.3.0:
+  version "136.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-136.3.0.tgz#1999c005dcb12c0add87d7a072a7d19c1d4f5e10"
+  integrity sha512-4oCbwIFROaefUki1GiItGg4fY7icklPaj6s5+MpWdvJHXQn6GB+EVBqfBewLDDQvMSd8xsP9w9UoiUWT2zpCZw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"


### PR DESCRIPTION
To be able to see a difference between selected items and new items

<img width="762" height="187" alt="image" src="https://github.com/user-attachments/assets/80349ab7-02a1-47f3-a2bc-60e70d5eaa96" />

https://www.notion.so/linagora/Drive-Board-20062718bad180d687d1f517b2ed7dda?p=2fd62718bad180809010e3f9eae9d0c3&pm=s

And now we get this with a cozy-ui upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest compatible versions for improved stability and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->