### PR TITLE
fix: Send returnUrl to notes app when shared drive recipient

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@sentry/react": "7.119.0",
     "classnames": "2.3.1",
     "cozy-bar": "^29.3.0",
-    "cozy-client": "^60.23.0",
+    "cozy-client": "^60.23.1",
     "cozy-dataproxy-lib": "^4.13.0",
     "cozy-device-helper": "^4.0.1",
     "cozy-devtools": "^1.2.1",

--- a/src/modules/navigation/PublicNoteRedirect.tsx
+++ b/src/modules/navigation/PublicNoteRedirect.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import { useI18n } from 'twake-i18n'
 
 import { useClient } from 'cozy-client'
@@ -15,6 +15,7 @@ import { DummyLayout } from '@/modules/layout/DummyLayout'
 const PublicNoteRedirect: FC = () => {
   const { t } = useI18n()
   const { fileId, driveId } = useParams()
+  const { search } = useLocation()
   const client = useClient()
 
   const [noteUrl, setNoteUrl] = useState<string | null>(null)
@@ -28,6 +29,9 @@ const PublicNoteRedirect: FC = () => {
 
       try {
         // Inside notes, we need to add / at the end of /public/ or /preview/ to avoid 409 error
+        const searchParams = new URLSearchParams(search)
+        const returnUrl = searchParams.get('returnUrl')
+
         const pathname =
           location.pathname === '/'
             ? '/public/'
@@ -39,7 +43,8 @@ const PublicNoteRedirect: FC = () => {
           },
           {
             driveId,
-            pathname
+            pathname,
+            returnUrl
           }
         )
         setNoteUrl(url)
@@ -52,7 +57,7 @@ const PublicNoteRedirect: FC = () => {
     if (fileId) {
       void fetchNoteUrl(fileId)
     }
-  }, [fileId, driveId, client])
+  }, [search, fileId, driveId, client])
 
   if (noteUrl) {
     window.location.href = noteUrl

--- a/src/modules/navigation/hooks/helpers.spec.js
+++ b/src/modules/navigation/hooks/helpers.spec.js
@@ -238,7 +238,7 @@ describe('computePath', () => {
     const file = { _id: 'note123', driveId: 'drive456' }
     expect(
       computePath(file, { type: 'public-note', pathname: '/public' })
-    ).toBe('/note/drive456/note123')
+    ).toBe('/note/drive456/note123?returnUrl=')
   })
 
   it('should return correct path for public-note-same-instance', () => {

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -1,3 +1,4 @@
+import CozyClient from 'cozy-client'
 import {
   isShortcut,
   isNote,
@@ -14,6 +15,7 @@ import {
   isNextcloudShortcut,
   isNextcloudFile
 } from '@/modules/nextcloud/helpers'
+import { makeSharedDriveNoteReturnUrl } from '@/modules/shareddrives/helpers'
 import { makeOnlyOfficeFileRoute } from '@/modules/views/OnlyOffice/helpers'
 
 interface ComputeFileTypeOptions {
@@ -26,6 +28,7 @@ interface ComputePathOptions {
   type: string
   pathname: string
   isPublic: boolean
+  client: CozyClient | null
 }
 
 export const computeFileType = (
@@ -92,7 +95,7 @@ export const computeApp = (type: string): string => {
 
 export const computePath = (
   file: File,
-  { type, pathname, isPublic }: ComputePathOptions
+  { type, pathname, isPublic, client }: ComputePathOptions
 ): string => {
   const paths = pathname.split('/').slice(1)
   const driveId = file.driveId as string | undefined
@@ -114,7 +117,17 @@ export const computePath = (
     case 'public-note-same-instance':
       return `/?id=${file._id}`
     case 'public-note':
-      return driveId ? `/note/${driveId}/${file._id}` : `/note/${file._id}`
+      if (driveId) {
+        const returnUrl = client
+          ? makeSharedDriveNoteReturnUrl(client, file as IOCozyFile)
+          : ''
+
+        return `/note/${driveId}/${file._id}?returnUrl=${encodeURIComponent(
+          returnUrl
+        )}`
+      } else {
+        return `/note/${file._id}`
+      }
     case 'docs':
       // eslint-disable-next-line no-case-declarations, @typescript-eslint/restrict-template-expressions
       return `/bridge/docs/${(file as IOCozyFile).metadata.externalId}`

--- a/src/modules/navigation/hooks/useFileLink.tsx
+++ b/src/modules/navigation/hooks/useFileLink.tsx
@@ -68,7 +68,8 @@ const useFileLink = (
   const path = computePath(file, {
     type,
     pathname,
-    isPublic
+    isPublic,
+    client
   })
 
   const shouldBeOpenedInNewTab =

--- a/src/modules/shareddrives/helpers.ts
+++ b/src/modules/shareddrives/helpers.ts
@@ -1,3 +1,4 @@
+import CozyClient, { generateWebLink } from 'cozy-client'
 import { IOCozyFile } from 'cozy-client/types/types'
 
 // Temporary type, need to be completed and then put in cozy-client
@@ -38,3 +39,19 @@ export const getFolderIdFromSharing = (
 
 export const isFromSharedDriveRecipient = (folder: IOCozyFile): boolean =>
   folder && Boolean(folder.driveId)
+
+export const makeSharedDriveNoteReturnUrl = (
+  client: CozyClient,
+  file: IOCozyFile
+): string => {
+  return generateWebLink({
+    slug: 'drive',
+    searchParams: [],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    cozyUrl: client.getStackClient().uri as string,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    subDomainType: client.getInstanceOptions().subdomain,
+    pathname: '',
+    hash: `/shareddrive/${file.driveId!}/${file.dir_id}`
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5861,10 +5861,10 @@ cozy-client@^60.20.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^60.23.0:
-  version "60.23.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.23.0.tgz#fa91e9bfee9bf0c56c2b49300c0d6ba628544321"
-  integrity sha512-JuoJRTbjwwMpmnLnSWGa0ZFekOcr3nwXieG5T5M9M/ISmAYI3ypR474zkNPbhq0J1OjYCSGxThBBpv45HPKBDA==
+cozy-client@^60.23.1:
+  version "60.23.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-60.23.1.tgz#009d056973769af69c0e9fe7386cda6c3d0aea3c"
+  integrity sha512-6Kw3exQxvfKCgmemdh8NqX9IZECj/W+QP+DYF8E4lniadXGWsY3drg2oNhyKwHHea+lRU2fEt776Pr0de6ZjTg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@fastify/deepmerge" "^2.0.2"


### PR DESCRIPTION
Required
https://github.com/linagora/cozy-notes/pull/501
https://github.com/linagora/cozy-client/pull/1677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public shared-drive notes now include and preserve a returnUrl parameter, so users are returned to their original location after viewing a shared note.
  * Link generation for shared-drive notes now computes and appends a return URL when available, improving navigation flow.

* **Bug Fixes**
  * Redirect handling for public note links now responds to changes in the URL query string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->