### PR TITLE
fix: Prevent rename input from losing focus on click

### DIFF
--- a/src/hooks/useShiftSelection/index.tsx
+++ b/src/hooks/useShiftSelection/index.tsx
@@ -17,6 +17,7 @@ import {
   FORWARD_DIRECTION
 } from './helpers'
 
+import { isEditableTarget } from '@/hooks/helpers'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { SelectedItems } from '@/modules/selection/types'
 
@@ -181,7 +182,9 @@ const useShiftSelection = (
     if (isMobile || !itemsRef.current.length || !ref.current) return
 
     const container = ref.current
-    container.focus()
+    if (!isEditableTarget(document.activeElement)) {
+      container.focus()
+    }
 
     container.addEventListener('keydown', handleKeyDown)
     return () => {


### PR DESCRIPTION
When clicking on the rename input, the useShiftSelection hook's useEffect was stealing focus by calling container.focus() after a selection state change. Now we skip focusing the container when an editable element (input, textarea, contentEditable) is already active.

https://www.notion.so/linagora/Drive-Board-20062718bad180d687d1f517b2ed7dda?p=31962718bad180239db4f7cd43ba952f&pm=s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved focus management behavior to prevent the container from taking focus away from active text inputs, textareas, and other editable fields when initializing. This ensures uninterrupted user interactions with form elements and improves the overall interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->