### PR TITLE
fix: Keep focus on rename input click on firefox

### DIFF
--- a/src/styles/filenameinput.styl
+++ b/src/styles/filenameinput.styl
@@ -4,6 +4,7 @@
     @extend $form-text
     display table-cell
     width 100%
+    user-select text
 
     input[type=text]
         width   100%


### PR DESCRIPTION
A fix has been done before to keep focus on rename input component but it did not work on firefox

On firefox, `user-select: none` on a parent component prevents a child input component to get the focus on click (different behavior from chrome).

We just need to add user-select: text on the input wrapper to fix this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enabled text selection in the file name input field, allowing users to easily select and copy file names for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->