### PR TITLE
fix: Allow sharing for shared drive recipient even if readonly

### DIFF
--- a/src/modules/actions/share.jsx
+++ b/src/modules/actions/share.jsx
@@ -29,13 +29,11 @@ const share = ({
     icon,
     allowInfectedFiles: false,
     displayCondition: files => {
-      // Not this sharing action in sharings tab
-      if (
-        shouldHideIfSharedDriveRecipient &&
-        files?.length === 1 &&
-        isFromSharedDriveRecipient(files[0])
-      ) {
-        return false
+      // If shared drive recipient:
+      // - in sharing view, we hide it because it works differently
+      // - in shared drive view, we show it
+      if (files?.length === 1 && isFromSharedDriveRecipient(files[0])) {
+        return !shouldHideIfSharedDriveRecipient
       }
 
       return (


### PR DESCRIPTION
Related to https://github.com/cozy/cozy-stack/pull/4698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined share action visibility logic for shared-drive recipients when handling single file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->