### PR TITLE
Add copy and download for shared folders

### DIFF
--- a/src/components/FolderPicker/types.ts
+++ b/src/components/FolderPicker/types.ts
@@ -11,4 +11,5 @@ export interface FolderPickerEntry {
   dir_id?: string
   class?: string
   path?: string
+  driveId?: string
 }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -72,11 +72,6 @@ declare module 'cozy-client/dist/models/file' {
     extension: string
   }
   export const isFile: (file: IOCozyFile) => boolean
-  export const copy: (
-    client: import('cozy-client/types/CozyClient').CozyClient,
-    file: Partial<import('components/FolderPicker/types').File>,
-    destination: import('components/FolderPicker/types').File
-  ) => Promise<void>
   export const isDirectory: (
     file: import('components/FolderPicker/types').File
   ) => boolean

--- a/src/hooks/useMoreMenuActions.jsx
+++ b/src/hooks/useMoreMenuActions.jsx
@@ -52,7 +52,6 @@ export const useMoreMenuActions = file => {
   const isPDFDoc = file.mime === 'application/pdf'
   const showPrintAction = isPDFDoc && isPrintAvailable
   const isCozySharing = window.location.pathname === '/preview'
-  const isSharedDrive = window.location.href.includes('/shareddrive/')
 
   const actions = makeActions(
     [
@@ -65,7 +64,7 @@ export const useMoreMenuActions = file => {
       details,
       hr,
       moveTo,
-      !isSharedDrive && duplicateTo, // TO DO: Remove condition when duplicating is available in shared drive
+      duplicateTo,
       addToFavorites,
       removeFromFavorites,
       hr,

--- a/src/modules/actions/download.jsx
+++ b/src/modules/actions/download.jsx
@@ -1,6 +1,5 @@
 import React, { forwardRef } from 'react'
 
-import { isDirectory } from 'cozy-client/dist/models/file'
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import DownloadIcon from 'cozy-ui/transpiled/react/Icons/Download'
@@ -33,7 +32,7 @@ export const download = ({
   t,
   vaultClient,
   showAlert,
-  driveId,
+  shouldHideIfSharedDriveRecipient,
   isSelectAll,
   displayedFolder
 }) => {
@@ -46,26 +45,13 @@ export const download = ({
     icon,
     allowInfectedFiles: false,
     displayCondition: files => {
-      // # We cannot download folders or multiple files in shared drives
-
-      // ## For sharing tab
+      // ## For sharing tab where we can see multiple shared folders as recipient,
+      // we disable it because we can not download different shared folders at same time
       if (
-        driveId &&
-        (files.length > 1 || (files.length === 1 && isDirectory(files[0])))
+        shouldHideIfSharedDriveRecipient &&
+        files.length > 1 &&
+        files.some(file => isFromSharedDriveRecipient(file))
       ) {
-        return false
-      }
-
-      // ## For shared drive view
-      const isSingleSharedDriveFolder =
-        files.length === 1 &&
-        isFromSharedDriveRecipient(files[0]) &&
-        isDirectory(files[0])
-
-      const hasMultipleFilesIncludeShareDriveFiles =
-        files.length > 1 && files.some(file => isFromSharedDriveRecipient(file))
-
-      if (isSingleSharedDriveFolder || hasMultipleFilesIncludeShareDriveFiles) {
         return false
       }
 
@@ -83,12 +69,7 @@ export const download = ({
       if (isSelectAll) {
         selectedFiles = [displayedFolder]
       }
-      return downloadFiles(
-        client,
-        selectedFiles,
-        { vaultClient, showAlert, t },
-        driveId
-      )
+      return downloadFiles(client, selectedFiles, { vaultClient, showAlert, t })
     },
     Component: makeComponent(label, icon)
   }

--- a/src/modules/actions/utils.js
+++ b/src/modules/actions/utils.js
@@ -30,13 +30,13 @@ const downloadFileError = error => {
 export const downloadFiles = async (
   client,
   files,
-  { vaultClient, showAlert, t } = {},
-  driveId
+  { vaultClient, showAlert, t } = {}
 ) => {
   const encryptionKey = await getEncryptionKeyFromDirId(client, files[0].dir_id)
 
   if (files.length === 1 && !isDirectory(files[0])) {
     const file = files[0]
+    const driveId = file.driveId
     try {
       const filename = file.name
       if (encryptionKey) {
@@ -71,7 +71,8 @@ export const downloadFiles = async (
       })
     }
     const ids = files.map(f => f.id)
-    return client.collection(DOCTYPE_FILES).downloadArchive(ids)
+    const driveId = files[0].driveId
+    return client.collection(DOCTYPE_FILES, { driveId }).downloadArchive(ids)
   }
 }
 

--- a/src/modules/drive/Toolbar/components/MoreMenu.jsx
+++ b/src/modules/drive/Toolbar/components/MoreMenu.jsx
@@ -93,9 +93,7 @@ const MoreMenu = ({
               displayedFolder={displayedFolder}
               folderId={folderId}
             >
-              {!isSharedDriveRecipient && (
-                <DownloadButtonItem files={[displayedFolder]} />
-              )}
+              <DownloadButtonItem files={[displayedFolder]} />
               <MoveItem
                 displayedFolder={displayedFolder}
                 hasWriteAccess={hasWriteAccess}

--- a/src/modules/duplicate/components/DuplicateModal.tsx
+++ b/src/modules/duplicate/components/DuplicateModal.tsx
@@ -2,8 +2,7 @@ import React, { FC, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useI18n } from 'twake-i18n'
 
-import { useClient } from 'cozy-client'
-import { copy } from 'cozy-client/dist/models/file'
+import { useClient, models } from 'cozy-client'
 import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 
 import { OpenFolderButton } from '@/components/Button/OpenFolderButton'
@@ -18,6 +17,7 @@ interface DuplicateModalProps {
   currentFolder: File
   onClose: () => void | Promise<void>
   showNextcloudFolder?: boolean
+  showSharedDriveFolder?: boolean
   isPublic?: boolean
 }
 
@@ -26,6 +26,7 @@ const DuplicateModal: FC<DuplicateModalProps> = ({
   currentFolder,
   onClose,
   showNextcloudFolder,
+  showSharedDriveFolder,
   isPublic
 }) => {
   const { t } = useI18n()
@@ -41,7 +42,11 @@ const DuplicateModal: FC<DuplicateModalProps> = ({
       setBusy(true)
       await Promise.all(
         entries.map(async entry => {
-          await registerCancelable(copy(client, entry as Partial<File>, folder))
+          await registerCancelable(
+            models.file.copy(client, entry as Partial<File>, folder, {
+              driveId: entry.driveId
+            })
+          )
         })
       )
 
@@ -90,6 +95,7 @@ const DuplicateModal: FC<DuplicateModalProps> = ({
   return (
     <FolderPicker
       showNextcloudFolder={showNextcloudFolder}
+      showSharedDriveFolder={showSharedDriveFolder}
       currentFolder={currentFolder}
       entries={entries}
       // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -36,6 +36,7 @@ import FileOpenerExternal from '@/modules/viewer/FileOpenerExternal'
 import { KonnectorRoutes } from '@/modules/views/Drive/KonnectorRoutes'
 import { FavoritesView } from '@/modules/views/Favorites/FavoritesView'
 import { FolderDuplicateView } from '@/modules/views/Folder/FolderDuplicateView'
+import { DuplicateSharedDriveFilesView } from '@/modules/views/Modal/DuplicateSharedDriveFilesView'
 import { MoveFilesView } from '@/modules/views/Modal/MoveFilesView'
 import { MoveSharedDriveFilesView } from '@/modules/views/Modal/MoveSharedDriveFilesView'
 import { QualifyFileView } from '@/modules/views/Modal/QualifyFileView'
@@ -148,6 +149,10 @@ const AppRoute = () => (
             <Route path="file/:fileId/share" element={<ShareFileView />} />
             <Route path="share" element={<ShareDisplayedFolderView />} />
             <Route path="move" element={<MoveSharedDriveFilesView />} />
+            <Route
+              path="duplicate"
+              element={<DuplicateSharedDriveFilesView />}
+            />
           </Route>
         </>
       ) : null}

--- a/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
+++ b/src/modules/shareddrives/components/SharedDriveFolderBody.jsx
@@ -20,6 +20,7 @@ import {
   hr,
   summariseByAI
 } from '@/modules/actions'
+import { duplicateTo } from '@/modules/actions/components/duplicateTo'
 import { moveTo } from '@/modules/actions/components/moveTo'
 import { FolderBody } from '@/modules/folder/components/FolderBody'
 
@@ -54,6 +55,7 @@ const SharedDriveFolderBody = ({
     byDocId,
     dispatch,
     canMove: canWriteToCurrentFolder,
+    canDuplicate: canWriteToCurrentFolder,
     navigate,
     showAlert,
     pushModal,
@@ -68,6 +70,7 @@ const SharedDriveFolderBody = ({
       hr,
       rename,
       moveTo,
+      duplicateTo,
       infos,
       hr,
       versions,

--- a/src/modules/views/Modal/DuplicateSharedDriveFilesView.jsx
+++ b/src/modules/views/Modal/DuplicateSharedDriveFilesView.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { useNavigate, useLocation, useParams } from 'react-router-dom'
+
+import { LoaderModal } from '@/components/LoaderModal'
+import useDisplayedFolder from '@/hooks/useDisplayedFolder'
+import { DuplicateModal } from '@/modules/duplicate/components/DuplicateModal'
+import { useQueryMultipleSharedDriveFolders } from '@/modules/shareddrives/hooks/useQueryMultipleSharedDriveFolders'
+
+const DuplicateSharedDriveFilesView = () => {
+  const navigate = useNavigate()
+  const { state } = useLocation()
+  const { driveId } = useParams()
+  const { displayedFolder } = useDisplayedFolder()
+
+  const { sharedDriveResults } = useQueryMultipleSharedDriveFolders({
+    folderIds: state?.fileIds ?? [],
+    driveId
+  })
+
+  if (sharedDriveResults && displayedFolder) {
+    const onClose = () => {
+      navigate('..', { replace: true })
+    }
+
+    const entries = sharedDriveResults.map(file => ({
+      ...file,
+      path: `${displayedFolder.path}/${file.name}`
+    }))
+
+    return (
+      <DuplicateModal
+        currentFolder={displayedFolder}
+        entries={entries}
+        onClose={onClose}
+        showSharedDriveFolder={true}
+      />
+    )
+  }
+
+  return <LoaderModal />
+}
+
+export { DuplicateSharedDriveFilesView }

--- a/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
+++ b/src/modules/views/SharedDrive/SharedDriveFolderView.jsx
@@ -27,6 +27,7 @@ import {
   hr,
   share
 } from '@/modules/actions'
+import { duplicateTo } from '@/modules/actions/components/duplicateTo'
 import { moveTo } from '@/modules/actions/components/moveTo'
 import { personalizeFolder } from '@/modules/actions/components/personalizeFolder'
 import AddMenuProvider from '@/modules/drive/AddMenu/AddMenuProvider'
@@ -110,6 +111,7 @@ const SharedDriveFolderView = () => {
       byDocId,
       dispatch,
       canMove: canWriteToCurrentFolder,
+      canDuplicate: canWriteToCurrentFolder,
       navigate,
       showAlert,
       pushModal,
@@ -146,6 +148,7 @@ const SharedDriveFolderView = () => {
           hr,
           rename,
           moveTo,
+          duplicateTo,
           personalizeFolder,
           infos,
           hr,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Duplicate action available in shared drive folders and a dedicated view for duplicating shared-drive files.
  - Download option shown for shared-drive recipients.

- **Refactor**
  - File operations and downloads now respect drive context across actions.

- **Style/Types**
  - Folder entries can optionally include a drive identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->