### PR TITLE
fix: Add left padding file items

### DIFF
--- a/src/modules/filelist/virtualized/cells/FileName.jsx
+++ b/src/modules/filelist/virtualized/cells/FileName.jsx
@@ -17,6 +17,26 @@ import {
 import FileThumbnail from '@/modules/filelist/icons/FileThumbnail'
 import FileNamePath from '@/modules/filelist/virtualized/cells/FileNamePath'
 
+const FileThumbnailComponent = ({ file, isInSyncFromSharing, isMobile }) => {
+  const { isBigThumbnail } = useThumbnailSizeContext()
+
+  return (
+    <div className="u-pl-half">
+      <FileThumbnail
+        file={file}
+        size={isBigThumbnail ? 96 : 32}
+        isInSyncFromSharing={isInSyncFromSharing}
+        showSharedBadge={isMobile}
+        componentsProps={{
+          sharedBadge: {
+            className: styles['fil-content-shared-vz']
+          }
+        }}
+      />
+    </div>
+  )
+}
+
 const FileName = ({
   attributes,
   isRenaming,
@@ -28,7 +48,6 @@ const FileName = ({
 }) => {
   const { t } = useI18n()
   const { title, filename, extension } = getFileNameAndExtension(attributes, t)
-  const { isBigThumbnail } = useThumbnailSizeContext()
   const { isMobile } = useBreakpoints()
 
   const parentFolderPath = makeParentFolderPath(attributes)
@@ -42,16 +61,10 @@ const FileName = ({
     return (
       <div className="u-flex">
         <div className="u-mr-half">
-          <FileThumbnail
+          <FileThumbnailComponent
             file={attributes}
-            size={isBigThumbnail ? 96 : 32}
             isInSyncFromSharing={isInSyncFromSharing}
-            showSharedBadge={isMobile}
-            componentsProps={{
-              sharedBadge: {
-                className: styles['fil-content-shared-vz']
-              }
-            }}
+            isMobile={isMobile}
           />
         </div>
         <RenameInput
@@ -68,16 +81,10 @@ const FileName = ({
     <span title={infected ? t('antivirus.infectedFile') : title}>
       <Filename
         icon={
-          <FileThumbnail
+          <FileThumbnailComponent
             file={attributes}
-            size={isBigThumbnail ? 96 : 32}
             isInSyncFromSharing={isInSyncFromSharing}
-            showSharedBadge={isMobile}
-            componentsProps={{
-              sharedBadge: {
-                className: styles['fil-content-shared-vz']
-              }
-            }}
+            isMobile={isMobile}
           />
         }
         variant="body1"


### PR DESCRIPTION
This prevents the file thumbnail from being completely flush with the left edge of the selected line

Before : 
<img width="334" height="135" alt="image" src="https://github.com/user-attachments/assets/8cc4b001-a53c-4f70-9e70-51225fff6a39" />

After:
<img width="334" height="135" alt="image" src="https://github.com/user-attachments/assets/0dbd203f-3307-4da1-886a-1229570faf7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal organization of thumbnail rendering in the file list by centralizing the thumbnail display logic, reducing code duplication and simplifying maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->