### PR TITLE
fix: Upgrade cozy-sharing to 30.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.14.1",
-    "cozy-sharing": "^28.11.3",
+    "cozy-sharing": "^30.0.1",
     "cozy-stack-client": "^60.23.0",
     "cozy-ui": "^137.0.0",
     "cozy-ui-plus": "^4.4.1",

--- a/src/components/IconStack/index.jsx
+++ b/src/components/IconStack/index.jsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import styles from './styles.styl'
+
+const IconStack = ({
+  backgroundClassName,
+  foregroundClassName,
+  backgroundIcon,
+  foregroundIcon,
+  offset
+}) => {
+  return (
+    <div
+      className={classNames(styles['IconStack-wrapper'], backgroundClassName)}
+    >
+      {backgroundIcon}
+      {foregroundIcon && (
+        <div
+          style={{
+            marginTop: offset?.vertical,
+            marginLeft: offset?.horizontal
+          }}
+          className={classNames(
+            styles['IconStack-foregroundIcon'],
+            foregroundClassName
+          )}
+        >
+          {foregroundIcon}
+        </div>
+      )}
+    </div>
+  )
+}
+
+IconStack.propTypes = {
+  backgroundClassName: PropTypes.string,
+  foregroundClassName: PropTypes.string,
+  backgroundIcon: PropTypes.node,
+  foregroundIcon: PropTypes.node,
+  offset: PropTypes.shape({
+    vertical: PropTypes.string,
+    horizontal: PropTypes.string
+  })
+}
+
+export default IconStack

--- a/src/components/IconStack/styles.styl
+++ b/src/components/IconStack/styles.styl
@@ -1,0 +1,9 @@
+.IconStack-wrapper
+    position relative
+    display inline-block
+
+.IconStack-foregroundIcon
+    position absolute
+    left 50%
+    top 50%
+    transform translate(-50%, -50%)

--- a/src/modules/views/Folder/CustomizedIcon.jsx
+++ b/src/modules/views/Folder/CustomizedIcon.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import IconStack from 'cozy-ui/transpiled/react/IconStack'
 
 import ColoredFolder from './ColoredFolder'
 
 import { getIcon } from '@/components/IconPicker/IconIndex'
+import IconStack from '@/components/IconStack'
 
 export const CustomizedIcon = ({
   selectedColor = '#46a2ff',

--- a/src/modules/views/Modal/QualifyFileView.jsx
+++ b/src/modules/views/Modal/QualifyFileView.jsx
@@ -8,12 +8,12 @@ import { isQualificationNote } from 'cozy-client/dist/models/document/documentTy
 import { getBoundT } from 'cozy-client/dist/models/document/locales'
 import flag from 'cozy-flags'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import IconStack from 'cozy-ui/transpiled/react/IconStack'
 import FileDuotoneIcon from 'cozy-ui/transpiled/react/Icons/FileDuotone'
 import FileTypeNoteIcon from 'cozy-ui/transpiled/react/Icons/FileTypeNote'
 import NestedSelectResponsive from 'cozy-ui/transpiled/react/NestedSelect/NestedSelectResponsive'
 import { useI18n } from 'twake-i18n'
 
+import IconStack from '@/components/IconStack'
 import { LoaderModal } from '@/components/LoaderModal'
 import { buildFileOrFolderByIdQuery } from '@/queries'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6377,10 +6377,10 @@ cozy-search@^0.14.1:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^28.11.3:
-  version "28.11.3"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-28.11.3.tgz#fbe2432dbba11edae2ef7b423b398a5085986fee"
-  integrity sha512-cNIH+c4/qi1jzeHHukA41xlexej8qongHAZSPSMPR1yUHsSAyPBNYmvj3YdcB6mxx/EaQTpTyHlrsfUei15m1Q==
+cozy-sharing@^30.0.1:
+  version "30.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-30.0.1.tgz#bf1e15566289ced973e0a3bbeb2ddaf68d139bde"
+  integrity sha512-dNzDdkqfIpWP7HEX42YMeOFG/DfhI1Cq72NvstvW6RRPfvWKrFkMmXLpk5k3XOl8F4l2+b3E+e3iDCnvj4SgVw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"


### PR DESCRIPTION
To get some updated locales

Had to import IconStack component source code to handle the upgrade of cozy-ui needed
by this cozy-sharing version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stacked-icon UI component to display layered icons with configurable foreground/background, offset, and styling.

* **Refactor**
  * Switched existing uses to the new local stacked-icon component for consistency.

* **Chores**
  * Updated the cozy-sharing dependency to a newer stable version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->