### PR TITLE
fix: Fix rename input click behavior (selection toggle + Firefox cursor)

### DIFF
--- a/src/modules/filelist/FileOpener.jsx
+++ b/src/modules/filelist/FileOpener.jsx
@@ -25,6 +25,10 @@ const FileOpener = ({
     onInteractWithFile
   })
 
+  if (isRenaming) {
+    return children
+  }
+
   return (
     <FileLink
       ref={rowRef}

--- a/src/modules/filelist/FilenameInput.jsx
+++ b/src/modules/filelist/FilenameInput.jsx
@@ -10,6 +10,7 @@ import { translate } from 'twake-i18n'
 import styles from '@/styles/filenameinput.styl'
 
 import { CozyFile } from '@/models'
+import { getCaretPositionFromPoint } from '@/modules/filelist/getCaretPositionFromPoint'
 
 const ENTER_KEY = 13
 const ESC_KEY = 27
@@ -152,6 +153,17 @@ const FilenameInput = ({
     shouldSetSelection.current = false
   }, [initialName, file])
 
+  // Firefox does not natively reposition the cursor on click in this DOM context.
+  // Workaround: manually compute and apply the caret position on mouseup.
+  const handleMouseUp = useCallback(e => {
+    const input = textInput.current
+    if (!input || e.target !== input) return
+    const offset = getCaretPositionFromPoint(e.clientX, e.clientY)
+    if (offset !== null) {
+      input.setSelectionRange(offset, offset)
+    }
+  }, [])
+
   return (
     <div
       data-testid="name-input"
@@ -167,6 +179,7 @@ const FilenameInput = ({
         onFocus={handleFocus}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
+        onMouseUp={handleMouseUp}
         className={error ? styles['error'] : null}
         autoFocus
       />

--- a/src/modules/filelist/getCaretPositionFromPoint.js
+++ b/src/modules/filelist/getCaretPositionFromPoint.js
@@ -1,0 +1,21 @@
+/**
+ * Get the caret offset in a text input from mouse coordinates.
+ *
+ * Uses `document.caretPositionFromPoint` (standard, Firefox) or
+ * `document.caretRangeFromPoint` (legacy, Chrome/Safari) to determine
+ * which character position the user clicked on.
+ *
+ * @param {number} x - clientX from the mouse event
+ * @param {number} y - clientY from the mouse event
+ * @returns {number|null} The character offset, or null if it cannot be determined
+ */
+export const getCaretPositionFromPoint = (x, y) => {
+  if (document.caretPositionFromPoint) {
+    const pos = document.caretPositionFromPoint(x, y)
+    if (pos) return pos.offset
+  } else if (document.caretRangeFromPoint) {
+    const range = document.caretRangeFromPoint(x, y)
+    if (range) return range.startOffset
+  }
+  return null
+}

--- a/src/modules/views/Folder/virtualized/Table.jsx
+++ b/src/modules/views/Folder/virtualized/Table.jsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState
 } from 'react'
+import { useSelector } from 'react-redux'
 
 import flag from 'cozy-flags'
 import VirtualizedTable from 'cozy-ui/transpiled/react/Table/Virtualized'
@@ -19,6 +20,7 @@ import styles from '@/styles/filelist.styl'
 
 import RightClickFileMenu from '@/components/RightClick/RightClickFileMenu'
 import { useClipboardContext } from '@/contexts/ClipboardProvider'
+import { isRenaming as isRenamingSelector } from '@/modules/drive/rename'
 import Cell from '@/modules/filelist/virtualized/cells/Cell'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
@@ -80,6 +82,7 @@ const Table = forwardRef(
   ) => {
     const { toggleSelectedItem, setSelectedItems } = useSelectionContext()
     const { isNew } = useNewItemHighlightContext()
+    const isRenamingActive = useSelector(isRenamingSelector)
     const internalVirtuosoRef = useRef(null)
     const virtuosoRef = parentVirtuosoRef || internalVirtuosoRef
     const [itemsInDropProcess, setItemsInDropProcess] = useState([])
@@ -89,6 +92,7 @@ const Table = forwardRef(
     const selectedItemsCount = Object.keys(selectedItems || {}).length
     const handleRowSelect = useCallback(
       (row, event) => {
+        if (isRenamingActive) return
         event?.stopPropagation?.()
         if (
           flag('drive.dynamic-selection.enabled') &&
@@ -105,7 +109,8 @@ const Table = forwardRef(
         toggleSelectedItem,
         onInteractWithFile,
         selectedItemsCount,
-        setSelectedItems
+        setSelectedItems,
+        isRenamingActive
       ]
     )
 


### PR DESCRIPTION
- When the `drive.dynamic-selection.enabled` flag is disabled, clicking on the rename input was toggling the row's selection state instead of positioning the cursor
- On Firefox, the cursor was not repositioned at all when clicking inside the rename input

## Changes

**Skip FileLink wrapper during rename** (`FileOpener.jsx`)
When renaming, the `FileOpener` returns children directly instead of wrapping them in a `FileLink` (`<a>` tag). This prevents the browser from navigating to the file viewer. The `<a>` tag's activation behavior fires regardless of `stopPropagation` (per HTML spec), and using `preventDefault` to block it also breaks cursor positioning on Firefox.

**Prevent row selection toggle during rename** (`Table.jsx`)
`handleRowSelect` now returns early when a rename is active. This is needed because cozy-ui's `VirtualizedTable` Cell calls the row `onClick` with `(row, column)` — not `(row, event)` — so it's not possible to filter clicks by event target.

**Manually reposition cursor on Firefox** (`FilenameInput.jsx`, `getCaretPositionFromPoint.js`)
Firefox does not natively reposition the cursor when clicking inside the rename input in this DOM context. A `mouseup` handler uses `document.caretPositionFromPoint` (standard/Firefox) or `document.caretRangeFromPoint` (Chrome/Safari) to manually compute and apply the caret position.

Other approaches were tested and failed:
- `stopPropagation` (React synthetic or native) on the input wrapper — did not fix cursor positioning on Firefox
- `preventDefault` on click to block `<a>` navigation — blocks cursor repositioning on Firefox
- `user-select: text` on the input element — no effect, computed value already resolves to `text`
- Changing `display: table-cell` to `display: block` on the wrapper — no effect

https://www.notion.so/linagora/Difficulty-renaming-a-file-or-folder-31962718bad180239db4f7cd43ba952f?d=f4a62718bad18314870903fbfa68c86d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text cursor positioning in filename inputs when clicking, including more consistent behavior across browsers.
  * Prevented row selection and interaction from interrupting an active file rename session.
  * Ensured file entries render appropriately while renaming to avoid unintended interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->