### PR TITLE
fix: deselect items when rectangular selection shrinks

### DIFF
--- a/src/modules/selection/RectangularSelection.jsx
+++ b/src/modules/selection/RectangularSelection.jsx
@@ -104,16 +104,16 @@ const RectangularSelection = ({
    */
   const handleSelect = useCallback(
     e => {
-      // Add newly selected items to the accumulated Set
+      const currentSelection = new Set(selectedDuringDragRef.current)
       for (const el of e.selected) {
         const file = getFileFromElement(el)
         if (file) {
-          selectedDuringDragRef.current.add(file._id)
+          currentSelection.add(file._id)
         }
       }
 
       const { newSelection, lastSelectedId } = buildSelectionFromItems(
-        selectedDuringDragRef.current,
+        currentSelection,
         itemsMap
       )
 


### PR DESCRIPTION
Previously, items were only added to the selection when dragging but never removed when the rectangle shrank. Now the selection set is cleared and rebuilt on each drag event with only the items currently inside the selection rectangle.

[Capture vidéo du 2026-03-27 10-00-05.webm](https://github.com/user-attachments/assets/bea65581-36e3-4f2c-b618-f232071772c8)

https://www.notion.so/linagora/Selection-Deselect-with-rectangle-33062718bad180dbb63aead374f5b43f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rectangular selection no longer carries over or mutates interim selection state during drag operations. Selections now reflect only the current drag (and explicit modifier seeding), preventing previously selected items from remaining selected unintentionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->