### PR TITLE
fix: drag & drop folder upload limited to 100 files

### DIFF
--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -317,7 +317,13 @@ export const processNextFile =
     )
   }
 
-const getFileFromEntry = entry => new Promise(resolve => entry.file(resolve))
+const getFileFromEntry = entry =>
+  new Promise((resolve, reject) => entry.file(resolve, reject))
+
+const readNextBatch = dirReader =>
+  new Promise((resolve, reject) =>
+    dirReader.readEntries(resolve, reject)
+  )
 
 const uploadDirectory = async (
   client,
@@ -328,39 +334,22 @@ const uploadDirectory = async (
 ) => {
   const newDir = await createFolder(client, directory.name, dirID, driveId)
   const dirReader = directory.createReader()
-  return new Promise(resolve => {
-    const entriesReader = async entries => {
-      for (let i = 0; i < entries.length; i += 1) {
-        const entry = entries[i]
-        if (entry.isFile) {
-          const file = await getFileFromEntry(entry)
-          await uploadFile(
-            client,
-            file,
-            newDir.id,
-            {
-              vaultClient,
-              encryptionKey
-            },
-            driveId
-          )
-        } else if (entry.isDirectory) {
-          await uploadDirectory(
-            client,
-            entry,
-            newDir.id,
-            {
-              vaultClient,
-              encryptionKey
-            },
-            driveId
-          )
-        }
+  const options = { vaultClient, encryptionKey }
+
+  // readEntries returns batches (typically ≤100 entries); loop until empty
+  let batch
+  while ((batch = await readNextBatch(dirReader)).length > 0) {
+    for (const entry of batch) {
+      if (entry.isFile) {
+        const file = await getFileFromEntry(entry)
+        await uploadFile(client, file, newDir.id, options, driveId)
+      } else if (entry.isDirectory) {
+        await uploadDirectory(client, entry, newDir.id, options, driveId)
       }
-      resolve(newDir)
     }
-    dirReader.readEntries(entriesReader)
-  })
+  }
+
+  return newDir
 }
 
 const createFolder = async (client, name, dirID, driveId) => {

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -321,9 +321,7 @@ const getFileFromEntry = entry =>
   new Promise((resolve, reject) => entry.file(resolve, reject))
 
 const readNextBatch = dirReader =>
-  new Promise((resolve, reject) =>
-    dirReader.readEntries(resolve, reject)
-  )
+  new Promise((resolve, reject) => dirReader.readEntries(resolve, reject))
 
 const uploadDirectory = async (
   client,


### PR DESCRIPTION
## Summary

- The browser's `readEntries()` API returns directory entries in batches (typically capped at 100 per call) -- we were calling it only once, silently dropping every file past the first batch
- Now loops until an empty batch is returned, so folders of any size are fully uploaded
- Also fixes a latent hang when `entry.file()` fails on an unreadable file (missing error callback)


https://github.com/user-attachments/assets/12d3927e-943c-4799-84ea-965ddef164b8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload failures now surface reliably so errors are reported instead of being hidden.
  * Directory uploads handle large or nested folders more robustly by reading and processing entries in repeated batches.
  * Uploads within a directory consistently use the same upload options for predictable behavior across all files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->