### PR TITLE
fix: refresh folder queries after uploading >100 files

### DIFF
--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -4,13 +4,19 @@ import { isDirectory } from 'cozy-client/dist/models/file'
 import flag from 'cozy-flags'
 import { QuotaPaywall } from 'cozy-ui-plus/dist/Paywall'
 
-import { ROOT_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
-import { MAX_PAYLOAD_SIZE_IN_GB } from '@/constants/config'
+import { resetQuery as resetQueryAction } from 'cozy-client/dist/store'
+
+import {
+  ROOT_DIR_ID,
+  TRASH_DIR_ID,
+  FILES_FETCH_LIMIT,
+  MAX_PAYLOAD_SIZE_IN_GB
+} from '@/constants/config'
 import { createEncryptedDir } from '@/lib/encryption'
 import { getEntriesTypeTranslated } from '@/lib/entries'
 import logger from '@/lib/logger'
 import { showModal } from '@/lib/react-cozy-helpers'
-import { getFolderContent } from '@/modules/selectors'
+import { getFolderContent, getFolderContentQueries } from '@/modules/selectors'
 import { addToUploadQueue } from '@/modules/upload'
 
 export const SORT_FOLDER = 'SORT_FOLDER'
@@ -26,6 +32,30 @@ export const sortFolder = (folderId, sortAttribute, sortOrder = 'asc') => {
     folderId,
     sortAttribute,
     sortOrder
+  }
+}
+
+/**
+ * Reset folder queries so the server re-sends proper paginated data.
+ * Works around cozy-client's sortAndLimitDocsIds capping realtime-added
+ * documents to `limit * fetchedPagesCount`, which hides files beyond
+ * the first page and leaves hasMore stale.
+ */
+const refetchFolderQueries = async (client, folderId) => {
+  try {
+    const storeState = client.store.getState()
+    const matchingQueries = getFolderContentQueries(storeState, folderId)
+
+    await Promise.all(
+      matchingQueries.map(async queryState => {
+        if (!queryState?.definition) return
+        // Clear stale pagination state then fetch every page
+        client.dispatch(resetQueryAction(queryState.id))
+        await client.queryAll(queryState.definition, { as: queryState.id })
+      })
+    )
+  } catch (error) {
+    logger.error('Failed to refetch folder queries after upload:', error)
   }
 }
 
@@ -76,7 +106,7 @@ export const uploadFiles =
           errors,
           updatedItems,
           fileTooLargeErrors
-        }) =>
+        }) => {
           dispatch(
             uploadQueueProcessed(
               createdItems,
@@ -91,7 +121,11 @@ export const uploadFiles =
               navigateAfterUpload,
               addItems
             )
-          ),
+          )
+          if (createdItems.length + updatedItems.length >= FILES_FETCH_LIMIT) {
+            refetchFolderQueries(client, targetDirId)
+          }
+        },
         { client, vaultClient },
         driveId,
         addItems

--- a/src/modules/selectors.js
+++ b/src/modules/selectors.js
@@ -5,7 +5,7 @@ import { getDocumentFromState } from 'cozy-client/dist/store'
 import { DOCTYPE_FILES } from '@/lib/doctypes'
 import { getMirrorQueryId, parseFolderQueryId } from '@/lib/queries'
 
-const getFolderContentQueries = (rootState, folderId) => {
+export const getFolderContentQueries = (rootState, folderId) => {
   const queries = rootState.cozy.queries
   const folderContentQueries = Object.entries(queries)
     .filter(([queryId]) => {


### PR DESCRIPTION
## Summary

- When uploading >100 files via the import button, only the first 100 appeared with no LoadMore button -- the user had to refresh the page and scroll to see the rest
- Root cause is in cozy-client's `sortAndLimitDocsIds` which caps query data to `limit * fetchedPagesCount` when documents arrive through realtime events, and never updates `hasMore` from mutations
- After the upload queue finishes, we now reset folder queries that have hit the page-size cap so the server re-sends proper paginated state with a working LoadMore


https://github.com/user-attachments/assets/6560e6c3-0cf2-48a0-a51f-ecd7fc050a3b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder contents now refresh reliably after file uploads, including large or paginated folders.
  * Uploads only trigger refetch when a substantial number of items were created or updated, reducing unnecessary refreshes.
  * Background refetching is more robust and failures are handled gracefully to avoid user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->