### PR TITLE
feat: Now show Create Button as the main button

### DIFF
--- a/src/modules/drive/Toolbar/components/AddButton.jsx
+++ b/src/modules/drive/Toolbar/components/AddButton.jsx
@@ -7,7 +7,7 @@ import { useI18n } from 'twake-i18n'
 
 import { AddMenuContext } from '@/modules/drive/AddMenu/AddMenuProvider'
 
-export const AddButton = ({ className, isPublic }) => {
+export const AddButton = ({ className }) => {
   const { t } = useI18n()
   const {
     anchorRef,
@@ -22,15 +22,7 @@ export const AddButton = ({ className, isPublic }) => {
     <div ref={anchorRef} onClick={isOffline ? handleOfflineClick : undefined}>
       <Button
         className={className}
-        variant={isPublic ? 'secondary' : 'primary'}
-        style={
-          isPublic
-            ? undefined
-            : {
-                color: 'var(--primaryTextColor)',
-                backgroundColor: 'var(--paperBackgroundColor)'
-              }
-        }
+        variant="primary"
         disabled={isDisabled || isOffline}
         startIcon={<Icon icon={PlusIcon} />}
         label={t('toolbar.menu_create')}

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -79,14 +79,6 @@ const LayoutContent = () => {
           <div>
             {isDesktop ? (
               <div className="u-mh-1-half u-mt-1-half">
-                <UploadButton
-                  componentsProps={{
-                    button: { className: 'u-w-100 u-bdrs-6' }
-                  }}
-                  label={t('upload.label')}
-                  displayedFolder={displayedFolder}
-                  disabled={isFolderReadOnly}
-                />
                 <AddMenuProvider
                   canCreateFolder={true}
                   canUpload={!isFolderReadOnly}
@@ -96,8 +88,16 @@ const LayoutContent = () => {
                   isReadOnly={isFolderReadOnly}
                   componentsProps={{ AddMenu: { isUploadDisabled: true } }}
                 >
-                  <AddButton className="u-w-100 u-bdrs-6 u-mt-half" />
+                  <AddButton className="u-w-100 u-bdrs-6 u-mt-half u-mb-half" />
                 </AddMenuProvider>
+                <UploadButton
+                  componentsProps={{
+                    button: { className: 'u-w-100 u-bdrs-6' }
+                  }}
+                  label={t('upload.label')}
+                  displayedFolder={displayedFolder}
+                  disabled={isFolderReadOnly}
+                />
               </div>
             ) : null}
             <Nav />

--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -69,13 +69,13 @@ const PublicToolbarByLink = ({
           <>
             {hasWriteAccess && (
               <>
+                <AddButton className="u-mr-half" isPublic />
                 <UploadButton
                   className="u-mr-half"
                   label={t('upload.label')}
                   displayedFolder={displayedFolder}
                   onUploaded={refreshFolderContent}
                 />
-                <AddButton className="u-mr-half" isPublic />
               </>
             )}
             {files.length > 0 && <DownloadFilesButton files={files} />}

--- a/src/modules/upload/UploadButton.jsx
+++ b/src/modules/upload/UploadButton.jsx
@@ -13,6 +13,7 @@ import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
 import { useI18n } from 'twake-i18n'
 
 import { uploadFiles } from '@/modules/navigation/duck'
+import { usePublicContext } from '@/modules/public/PublicProvider'
 import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
 
 const UploadButton = ({
@@ -50,6 +51,8 @@ const UploadButton = ({
     )
   }
 
+  const { isPublic } = usePublicContext()
+
   return (
     <FileInput
       className={className}
@@ -62,6 +65,15 @@ const UploadButton = ({
     >
       <Button
         {...componentsProps?.button}
+        variant={isPublic ? 'secondary' : 'primary'}
+        style={
+          isPublic
+            ? undefined
+            : {
+                color: 'var(--primaryTextColor)',
+                backgroundColor: 'var(--paperBackgroundColor)'
+              }
+        }
         component="span"
         startIcon={<Icon icon={UploadIcon} />}
         label={label}


### PR DESCRIPTION
Instead of the upload button

In the drive page 

<img width="229" height="136" alt="Capture d’écran du 2026-03-30 08-14-29" src="https://github.com/user-attachments/assets/e29f9e2c-020b-4106-a947-dc47cb2ef79c" />


and in the public page

<img width="599" height="83" alt="image" src="https://github.com/user-attachments/assets/609c0b3b-d1ca-4d0c-9418-93e15b6816ae" />

https://www.notion.so/linagora/Sidebar-design-changes-33062718bad1809697d4e0758874cb28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized toolbar button order for more consistent desktop and public views.
  * Simplified the Add button's public API and unified its styling so it always uses the primary variant.
  * Upload button now adapts its appearance between public and private modes for clearer visual distinction.
  * Adjusted Add button spacing to improve layout alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->