### PR TITLE
fix: Extend select on edge and shrink

### DIFF
--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
 import { isDirectory } from 'cozy-client/dist/models/file'
+import { resetQuery as resetQueryAction } from 'cozy-client/dist/store'
 import flag from 'cozy-flags'
 import { QuotaPaywall } from 'cozy-ui-plus/dist/Paywall'
-
-import { resetQuery as resetQueryAction } from 'cozy-client/dist/store'
 
 import {
   ROOT_DIR_ID,

--- a/src/modules/selection/RectangularSelection.jsx
+++ b/src/modules/selection/RectangularSelection.jsx
@@ -27,6 +27,46 @@ const buildSelectionFromItems = (fileIds, itemsMap) => {
   return { newSelection, lastSelectedId }
 }
 
+const getVisibleFileIdsFromSelecto = selectoRef => {
+  const selectableElements = selectoRef.current?.getSelectableElements() || []
+  const visibleFileIds = new Set()
+  for (const el of selectableElements) {
+    const fileId = el.getAttribute('data-file-id')
+    if (fileId) {
+      visibleFileIds.add(fileId)
+    }
+  }
+  return visibleFileIds
+}
+
+const getSelectedFileIdsFromSelectoEvent = (e, getFileFromElement) => {
+  const selectedFileIds = new Set()
+  for (const el of e.selected) {
+    const file = getFileFromElement(el)
+    if (file) {
+      selectedFileIds.add(file._id)
+    }
+  }
+  return selectedFileIds
+}
+
+const accumulateSelectedItemsDuringDrag = (
+  selectedDuringDragRef,
+  selectedFileIds,
+  visibleFileIds
+) => {
+  const newAccumulated = new Set()
+  for (const fileId of selectedDuringDragRef.current) {
+    if (!visibleFileIds.has(fileId) || selectedFileIds.has(fileId)) {
+      newAccumulated.add(fileId)
+    }
+  }
+  for (const fileId of selectedFileIds) {
+    newAccumulated.add(fileId)
+  }
+  return newAccumulated
+}
+
 /**
  * Component that enables rectangular selection of files in a grid view.
  * Wraps children with a selection area that allows users to drag-select
@@ -104,16 +144,20 @@ const RectangularSelection = ({
    */
   const handleSelect = useCallback(
     e => {
-      const currentSelection = new Set(selectedDuringDragRef.current)
-      for (const el of e.selected) {
-        const file = getFileFromElement(el)
-        if (file) {
-          currentSelection.add(file._id)
-        }
-      }
+      const visibleFileIds = getVisibleFileIdsFromSelecto(selectoRef)
+      const selectedFileIds = getSelectedFileIdsFromSelectoEvent(
+        e,
+        getFileFromElement
+      )
+      const newAccumulated = accumulateSelectedItemsDuringDrag(
+        selectedDuringDragRef,
+        selectedFileIds,
+        visibleFileIds
+      )
+      selectedDuringDragRef.current = newAccumulated
 
       const { newSelection, lastSelectedId } = buildSelectionFromItems(
-        currentSelection,
+        newAccumulated,
         itemsMap
       )
 


### PR DESCRIPTION

[Capture vidéo du 2026-03-31 08-28-44.webm](https://github.com/user-attachments/assets/9afe8ff3-8755-4e33-af0a-d01f2d03278a)

The previous fix (dc1b797) introduced selectedDuringDragRef to accumulate
selected items during drag, preventing loss when items scroll out of view.
However, commit 9a9c977 broke this by only copying the ref to a local
variable without updating the ref itself.

This commit restores the proper accumulation behavior by:
- Updating selectedDuringDragRef with newly selected items
- Only removing items from the ref when they scroll out of view (not visible)
  but are no longer in the current selection rectangle
- Items that remain visible but exit the rectangle are correctly deselected
  in the UI while being preserved in the ref for potential re-selection

Refactoring: extracted helper functions for better readability:
- getVisibleFileIdsFromSelecto
- getSelectedFileIdsFromSelectoEvent
- accumulateSelectedItemsDuringDrag



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rectangular selection logic to properly track and accumulate visible files during drag operations.

* **Chores**
  * Reorganized imports for code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->