### PR TITLE
feat: allow Ctrl+Click to toggle individual item selection

### DIFF
--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -26,7 +26,12 @@ export const handleClick = ({
   // simply remove this "if" the flag is not necessary anymore
   if (!flag('drive.doubleclick.enabled')) {
     if (selectionModeActive) {
-      if (flag('drive.dynamic-selection.enabled') && !event.shiftKey) {
+      if (
+        flag('drive.dynamic-selection.enabled') &&
+        !event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey
+      ) {
         event.stopPropagation()
         setSelectedItems({ [file._id]: file })
         onInteractWithFile?.(file._id, event)
@@ -43,6 +48,8 @@ export const handleClick = ({
 
   if (isDoubleClick) {
     openLink(event)
+  } else if (event.ctrlKey || event.metaKey) {
+    toggle(event)
   } else {
     // we should not use file.index
     // we should probablt not use index - 1

--- a/src/hooks/useOnLongPress/helpers.spec.jsx
+++ b/src/hooks/useOnLongPress/helpers.spec.jsx
@@ -1,6 +1,10 @@
 import MockDate from 'mockdate'
 
+import flag from 'cozy-flags'
+
 import { handlePress, handleClick } from './helpers'
+
+jest.mock('cozy-flags', () => jest.fn())
 
 const mockToggle = jest.fn()
 const mockOpenLink = jest.fn()
@@ -124,6 +128,147 @@ describe('handleClick', () => {
 
       expect(mockToggle).not.toHaveBeenCalledWith()
       expect(mockOpenLink).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with dynamic-selection enabled and selectionModeActive', () => {
+    const file = { _id: 'file-1' }
+    const mockSetSelectedItems = jest.fn()
+    const mockOnInteractWithFile = jest.fn()
+
+    const setupDynamic = (eventOverrides = {}) => {
+      flag.mockImplementation(name => {
+        if (name === 'drive.dynamic-selection.enabled') return true
+        if (name === 'drive.doubleclick.enabled') return false
+        return false
+      })
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        ...eventOverrides
+      }
+
+      return {
+        params: {
+          event,
+          file,
+          disabled: false,
+          isRenaming: false,
+          openLink: mockOpenLink,
+          toggle: mockToggle,
+          selectionModeActive: true,
+          lastClickTime: 0,
+          setLastClickTime: jest.fn(),
+          setSelectedItems: mockSetSelectedItems,
+          onInteractWithFile: mockOnInteractWithFile,
+          clearHighlightedItems: jest.fn()
+        },
+        event
+      }
+    }
+
+    afterEach(() => {
+      flag.mockReset()
+    })
+
+    it('should replace selection on simple click', () => {
+      const { params } = setupDynamic()
+      handleClick(params)
+
+      expect(mockSetSelectedItems).toHaveBeenCalledWith({
+        [file._id]: file
+      })
+      expect(mockToggle).not.toHaveBeenCalled()
+    })
+
+    it('should toggle item on Ctrl+Click', () => {
+      const { params, event } = setupDynamic({ ctrlKey: true })
+      handleClick(params)
+
+      expect(mockToggle).toHaveBeenCalledWith(event)
+      expect(mockSetSelectedItems).not.toHaveBeenCalled()
+    })
+
+    it('should toggle item on Cmd+Click (metaKey)', () => {
+      const { params, event } = setupDynamic({ metaKey: true })
+      handleClick(params)
+
+      expect(mockToggle).toHaveBeenCalledWith(event)
+      expect(mockSetSelectedItems).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with doubleclick enabled', () => {
+    const file = { _id: 'file-1' }
+    const mockSetSelectedItems = jest.fn()
+    const mockOnInteractWithFile = jest.fn()
+
+    const setupDoubleClick = (eventOverrides = {}) => {
+      flag.mockImplementation(name => {
+        if (name === 'drive.doubleclick.enabled') return true
+        return false
+      })
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        ...eventOverrides
+      }
+
+      return {
+        params: {
+          event,
+          file,
+          disabled: false,
+          isRenaming: false,
+          openLink: mockOpenLink,
+          toggle: mockToggle,
+          selectionModeActive: true,
+          lastClickTime: 0,
+          setLastClickTime: jest.fn(),
+          setSelectedItems: mockSetSelectedItems,
+          onInteractWithFile: mockOnInteractWithFile,
+          clearHighlightedItems: jest.fn()
+        },
+        event
+      }
+    }
+
+    afterEach(() => {
+      flag.mockReset()
+    })
+
+    it('should replace selection on simple click', () => {
+      const { params } = setupDoubleClick()
+      handleClick(params)
+
+      expect(mockSetSelectedItems).toHaveBeenCalledWith({
+        [file._id]: file
+      })
+      expect(mockToggle).not.toHaveBeenCalled()
+    })
+
+    it('should toggle item on Ctrl+Click', () => {
+      const { params, event } = setupDoubleClick({ ctrlKey: true })
+      handleClick(params)
+
+      expect(mockToggle).toHaveBeenCalledWith(event)
+      expect(mockSetSelectedItems).not.toHaveBeenCalled()
+    })
+
+    it('should toggle item on Cmd+Click (metaKey)', () => {
+      const { params, event } = setupDoubleClick({ metaKey: true })
+      handleClick(params)
+
+      expect(mockToggle).toHaveBeenCalledWith(event)
+      expect(mockSetSelectedItems).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
[Capture vidéo du 2026-03-31 08-32-41.webm](https://github.com/user-attachments/assets/28228927-f4de-4ca5-a878-a5fa3056a381)

When a selection exists, Ctrl+Click (Cmd+Click on Mac) now toggles the clicked item without affecting the rest of the selection, instead of replacing the entire selection with just that item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file selection so Ctrl/Cmd and other modifier-assisted clicks behave consistently across selection modes and double-click settings: modifier clicks now toggle selection while plain clicks replace selection.

* **Tests**
  * Added tests covering selection interactions under different feature-flag configurations and keyboard modifier states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->