### PR TITLE
feat: block uploads exceeding 500 files with a warning dialog

### DIFF
--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -17,6 +17,7 @@ export const KONNECTORS_DIR_PATH = '/.cozy_konnectors'
 export const FILES_FETCH_LIMIT = 100
 export const MAX_PAYLOAD_SIZE_IN_GB = 5
 export const MAX_PAYLOAD_SIZE = MAX_PAYLOAD_SIZE_IN_GB * 1024 * 1024 * 1024
+export const MAX_UPLOAD_FILE_COUNT = 500
 export const SHARING_TAB_ALL = 0
 export const SHARING_TAB_DRIVES = 1
 export const DEFAULT_UPLOAD_PROGRESS_HIDE_DELAY = 5000

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -358,6 +358,12 @@
       "errors": "Errors occurred during the %{type} upload.",
       "network": "You are currenly offline. Please try again once you're connected.",
       "fileTooLargeErrors": "File too large. Maximum file size: %{max_size_value} GB"
+    },
+    "limit": {
+      "title": "You cannot upload more than %{limit} files at a time.",
+      "content": "Need to upload more? Consider downloading the synchronization tool to your computer",
+      "cancel": "Cancel",
+      "download_desktop": "Download on Desktop"
     }
   },
   "intents": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -355,6 +355,12 @@
       "errors": "Une erreur est survenue lors de l’import du %{type}, merci de réessayer plus tard.",
       "network": "Vous ne disposez pas d'une connexion internet. Merci de réessayer quand ce sera le cas.",
       "fileTooLargeErrors": "Fichier trop volumineux. Taille maximale autorisée par fichier : %{max_size_value} Go"
+    },
+    "limit": {
+      "title": "Vous ne pouvez pas importer plus de %{limit} fichiers à la fois.",
+      "content": "Besoin d'en importer davantage\u00a0? Téléchargez l'outil de synchronisation sur votre ordinateur",
+      "cancel": "Annuler",
+      "download_desktop": "Télécharger sur ordinateur"
     }
   },
   "intents": {

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -9,14 +9,20 @@ import {
   ROOT_DIR_ID,
   TRASH_DIR_ID,
   FILES_FETCH_LIMIT,
-  MAX_PAYLOAD_SIZE_IN_GB
+  MAX_PAYLOAD_SIZE_IN_GB,
+  MAX_UPLOAD_FILE_COUNT
 } from '@/constants/config'
 import { createEncryptedDir } from '@/lib/encryption'
 import { getEntriesTypeTranslated } from '@/lib/entries'
 import logger from '@/lib/logger'
 import { showModal } from '@/lib/react-cozy-helpers'
 import { getFolderContent, getFolderContentQueries } from '@/modules/selectors'
-import { addToUploadQueue } from '@/modules/upload'
+import {
+  addToUploadQueue,
+  extractFilesEntries,
+  exceedsFileLimit
+} from '@/modules/upload'
+import UploadLimitDialog from '@/modules/upload/UploadLimitDialog'
 
 export const SORT_FOLDER = 'SORT_FOLDER'
 export const OPERATION_REDIRECTED = 'navigation/OPERATION_REDIRECTED'
@@ -82,7 +88,7 @@ export const uploadFiles =
     driveId,
     addItems
   ) =>
-  dispatch => {
+  async dispatch => {
     let targetDirId = dirId
     let navigateAfterUpload = false
 
@@ -91,9 +97,20 @@ export const uploadFiles =
       navigateAfterUpload = true
     }
 
+    const maxFileCount =
+      flag('drive.max-upload-file-count') ?? MAX_UPLOAD_FILE_COUNT
+
+    // Extract entries synchronously before browser clears dataTransfer
+    const entries = extractFilesEntries(files)
+
+    if (await exceedsFileLimit(entries, maxFileCount)) {
+      dispatch(showModal(<UploadLimitDialog maxFileCount={maxFileCount} />))
+      return
+    }
+
     dispatch(
       addToUploadQueue(
-        files,
+        entries,
         targetDirId,
         sharingState,
         fileUploadedCallback,

--- a/src/modules/navigation/duck/actions.spec.jsx
+++ b/src/modules/navigation/duck/actions.spec.jsx
@@ -1,9 +1,34 @@
 import CozyClient from 'cozy-client'
+import flag from 'cozy-flags'
 import { WebVaultClient } from 'cozy-keys-lib'
 
-import { createFolder } from './actions'
+import { createFolder, uploadFiles } from './actions'
 import { generateFile } from 'test/generate'
 import { setupFolderContent } from 'test/setup'
+
+import {
+  addToUploadQueue,
+  extractFilesEntries,
+  exceedsFileLimit
+} from '@/modules/upload'
+
+jest.mock('cozy-flags', () => jest.fn(() => null))
+
+jest.mock('@/modules/upload', () => ({
+  addToUploadQueue: jest.fn(() => () => {}),
+  extractFilesEntries: jest.fn(),
+  exceedsFileLimit: jest.fn()
+}))
+
+jest.mock('@/modules/upload/UploadLimitDialog', () => {
+  const React = require('react')
+  return function MockUploadLimitDialog(props) {
+    return React.createElement('div', {
+      'data-testid': 'upload-limit-dialog',
+      ...props
+    })
+  }
+})
 
 jest.mock('cozy-keys-lib', () => ({
   withVaultClient: jest.fn().mockReturnValue({}),
@@ -75,5 +100,98 @@ describe('createFolder', () => {
       name: 'foobar5',
       type: 'directory'
     })
+  })
+})
+
+describe('uploadFiles', () => {
+  const mockFiles = [new File([''], 'test.txt')]
+  const mockEntries = [{ file: mockFiles[0], isDirectory: false, entry: null }]
+  const deps = {
+    client: {},
+    vaultClient: {},
+    showAlert: jest.fn(),
+    t: x => x
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    extractFilesEntries.mockReturnValue(mockEntries)
+    flag.mockReturnValue(null)
+  })
+
+  it('should block upload and show limit dialog when limit is exceeded', async () => {
+    exceedsFileLimit.mockResolvedValue(true)
+
+    const dispatch = jest.fn()
+    await uploadFiles(mockFiles, 'dir-id', {}, () => null, deps)(dispatch)
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SHOW_MODAL' })
+    )
+    expect(addToUploadQueue).not.toHaveBeenCalled()
+  })
+
+  it('should proceed with upload when limit is not exceeded', async () => {
+    exceedsFileLimit.mockResolvedValue(false)
+
+    const dispatch = jest.fn()
+    await uploadFiles(mockFiles, 'dir-id', {}, () => null, deps)(dispatch)
+
+    expect(addToUploadQueue).toHaveBeenCalledWith(
+      mockEntries,
+      'dir-id',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ client: deps.client }),
+      undefined,
+      undefined
+    )
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SHOW_MODAL' })
+    )
+  })
+
+  it('should use flag value as limit when set', async () => {
+    flag.mockReturnValue(100)
+    exceedsFileLimit.mockResolvedValue(true)
+
+    const dispatch = jest.fn()
+    await uploadFiles(mockFiles, 'dir-id', {}, () => null, deps)(dispatch)
+
+    expect(exceedsFileLimit).toHaveBeenCalledWith(mockEntries, 100)
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SHOW_MODAL' })
+    )
+  })
+
+  it('should fall back to default limit when flag is not set', async () => {
+    flag.mockReturnValue(null)
+    exceedsFileLimit.mockResolvedValue(false)
+
+    const dispatch = jest.fn()
+    await uploadFiles(mockFiles, 'dir-id', {}, () => null, deps)(dispatch)
+
+    expect(exceedsFileLimit).toHaveBeenCalledWith(mockEntries, 500)
+    expect(addToUploadQueue).toHaveBeenCalled()
+  })
+
+  it('should pass pre-extracted entries to addToUploadQueue', async () => {
+    exceedsFileLimit.mockResolvedValue(false)
+
+    const dispatch = jest.fn()
+    await uploadFiles(mockFiles, 'dir-id', {}, () => null, deps)(dispatch)
+
+    expect(extractFilesEntries).toHaveBeenCalledWith(mockFiles)
+    expect(addToUploadQueue).toHaveBeenCalledWith(
+      mockEntries,
+      'dir-id',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ client: deps.client }),
+      undefined,
+      undefined
+    )
   })
 })

--- a/src/modules/upload/UploadLimitDialog.jsx
+++ b/src/modules/upload/UploadLimitDialog.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import DesktopDownloadIcon from 'cozy-ui/transpiled/react/Icons/DesktopDownload'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { useI18n } from 'twake-i18n'
+
+import { getDesktopAppDownloadLink } from '@/components/pushClient'
+import { usePublicContext } from '@/modules/public/PublicProvider'
+
+const UploadLimitDialog = ({ onClose, maxFileCount }) => {
+  const { t } = useI18n()
+  const { isPublic } = usePublicContext()
+
+  const handleDownloadDesktop = () => {
+    const link = getDesktopAppDownloadLink({ t })
+    window.open(link, '_blank', 'noopener,noreferrer')
+    onClose()
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      title={t('upload.limit.title', { limit: maxFileCount })}
+      content={<Typography>{t('upload.limit.content')}</Typography>}
+      actions={
+        <>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            label={t('upload.limit.cancel')}
+          />
+          {!isPublic && (
+            <Button
+              onClick={handleDownloadDesktop}
+              label={t('upload.limit.download_desktop')}
+              startIcon={<Icon icon={DesktopDownloadIcon} />}
+            />
+          )}
+        </>
+      }
+    />
+  )
+}
+
+export default UploadLimitDialog

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -484,7 +484,7 @@ export const removeFileToUploadQueue = file => async dispatch => {
 
 export const addToUploadQueue =
   (
-    files,
+    entries,
     dirID,
     sharingState,
     fileUploadedCallback,
@@ -496,7 +496,7 @@ export const addToUploadQueue =
   async dispatch => {
     dispatch({
       type: ADD_TO_UPLOAD_QUEUE,
-      files: extractFilesEntries(files)
+      files: entries
     })
     dispatch(
       processNextFile(
@@ -575,7 +575,7 @@ export const selectors = {
 }
 
 // DOM helpers
-const extractFilesEntries = items => {
+export const extractFilesEntries = items => {
   let results = []
   for (let i = 0; i < items.length; i += 1) {
     const item = items[i]
@@ -596,4 +596,52 @@ const extractFilesEntries = items => {
   }
 
   return results
+}
+
+/**
+ * Recursively count all files inside a directory entry.
+ *
+ * @param {FileSystemDirectoryEntry} directoryEntry - A directory obtained from the drag-and-drop FileSystem API
+ * @returns {Promise<number>} Total number of files (excluding sub-directories themselves)
+ */
+const countDirectoryFiles = async directoryEntry => {
+  const reader = directoryEntry.createReader()
+  const childEntries = await readAllEntries(reader)
+  let count = 0
+  for (const entry of childEntries) {
+    if (entry.isFile) {
+      count += 1
+    } else if (entry.isDirectory) {
+      count += await countDirectoryFiles(entry)
+    }
+  }
+  return count
+}
+
+/**
+ * Check whether the total number of files in the given entries exceeds
+ * the provided limit. Directories are counted in parallel for speed.
+ * Flat files are checked first to avoid directory traversal when possible.
+ *
+ * @param {Array<{file: File, isDirectory: boolean, entry: FileSystemEntry|null}>} entries - Extracted entries from {@link extractFilesEntries}
+ * @param {number} limit - Maximum number of files allowed
+ * @returns {Promise<boolean>} `true` if the file count exceeds the limit
+ */
+export const exceedsFileLimit = async (entries, limit) => {
+  const fileCount = entries.filter(e => !e.isDirectory || !e.entry).length
+  const directories = entries.filter(e => e.isDirectory && e.entry)
+
+  if (fileCount > limit) return true
+
+  const dirCounts = await Promise.all(
+    directories.map(e => countDirectoryFiles(e.entry))
+  )
+
+  let count = fileCount
+  for (const dirCount of dirCounts) {
+    count += dirCount
+    if (count > limit) return true
+  }
+
+  return false
 }

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -3,7 +3,9 @@ import {
   selectors,
   queue,
   overwriteFile,
-  uploadProgress
+  uploadProgress,
+  extractFilesEntries,
+  exceedsFileLimit
 } from './index'
 
 import { getEncryptionKeyFromDirId } from '@/lib/encryption'
@@ -566,6 +568,174 @@ describe('queue reducer', () => {
       const result3 = queue(result2, { type: 'RECEIVE_UPLOAD_ERROR', file })
       expect(result3[0].progress).toEqual(null)
     })
+  })
+})
+
+// Helpers to mock browser FileSystem API objects
+const createMockFileEntry = name => ({
+  isFile: true,
+  isDirectory: false,
+  name
+})
+
+const createMockDirEntry = (name, children) => ({
+  isFile: false,
+  isDirectory: true,
+  name,
+  createReader: () => {
+    let read = false
+    return {
+      readEntries: resolve => {
+        if (!read) {
+          read = true
+          resolve(children)
+        } else {
+          resolve([])
+        }
+      }
+    }
+  }
+})
+
+describe('extractFilesEntries', () => {
+  it('should extract plain File objects', () => {
+    const files = [new File(['a'], 'a.txt'), new File(['b'], 'b.txt')]
+    const result = extractFilesEntries(files)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      file: files[0],
+      isDirectory: false,
+      entry: null
+    })
+  })
+
+  it('should extract DataTransferItem with file entry', () => {
+    const file = new File(['a'], 'a.txt')
+    const fileEntry = { isFile: true, isDirectory: false }
+    const items = [
+      {
+        webkitGetAsEntry: () => fileEntry,
+        getAsFile: () => file
+      }
+    ]
+    const result = extractFilesEntries(items)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      file,
+      isDirectory: false,
+      entry: fileEntry
+    })
+  })
+
+  it('should extract DataTransferItem with directory entry', () => {
+    const dirEntry = { isFile: false, isDirectory: true }
+    const items = [
+      {
+        webkitGetAsEntry: () => dirEntry,
+        getAsFile: () => null
+      }
+    ]
+    const result = extractFilesEntries(items)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      file: null,
+      isDirectory: true,
+      entry: dirEntry
+    })
+  })
+
+  it('should handle empty items', () => {
+    const result = extractFilesEntries([])
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('exceedsFileLimit', () => {
+  it('should return false when flat files are under the limit', async () => {
+    const entries = [
+      { file: new File(['a'], 'a.txt'), isDirectory: false, entry: null },
+      { file: new File(['b'], 'b.txt'), isDirectory: false, entry: null },
+      { file: new File(['c'], 'c.txt'), isDirectory: false, entry: null }
+    ]
+    expect(await exceedsFileLimit(entries, 500)).toBe(false)
+  })
+
+  it('should return false when total including directories is under the limit', async () => {
+    const dirEntry = createMockDirEntry('photos', [
+      createMockFileEntry('img1.jpg'),
+      createMockFileEntry('img2.jpg')
+    ])
+    const entries = [
+      { file: null, isDirectory: true, entry: dirEntry },
+      { file: new File(['a'], 'doc.txt'), isDirectory: false, entry: null }
+    ]
+    expect(await exceedsFileLimit(entries, 500)).toBe(false)
+  })
+
+  it('should count files in nested directories', async () => {
+    const subDir = createMockDirEntry('sub', [createMockFileEntry('deep.txt')])
+    const topDir = createMockDirEntry('top', [
+      createMockFileEntry('shallow.txt'),
+      subDir
+    ])
+    const entries = [{ file: null, isDirectory: true, entry: topDir }]
+    expect(await exceedsFileLimit(entries, 1)).toBe(true)
+    expect(await exceedsFileLimit(entries, 2)).toBe(false)
+  })
+
+  it('should return false for empty directories', async () => {
+    const emptyDir = createMockDirEntry('empty', [])
+    const entries = [
+      { file: null, isDirectory: true, entry: emptyDir },
+      { file: new File(['a'], 'a.txt'), isDirectory: false, entry: null }
+    ]
+    expect(await exceedsFileLimit(entries, 500)).toBe(false)
+  })
+
+  it('should return false for empty entries', async () => {
+    expect(await exceedsFileLimit([], 500)).toBe(false)
+  })
+
+  it('should return true when flat files alone exceed the limit', async () => {
+    const entries = Array.from({ length: 600 }, (_, i) => ({
+      file: new File([''], `file${i}.txt`),
+      isDirectory: false,
+      entry: null
+    }))
+    expect(await exceedsFileLimit(entries, 500)).toBe(true)
+  })
+
+  it('should return false when files across multiple directories are under the limit', async () => {
+    const dir1 = createMockDirEntry(
+      'dir1',
+      Array.from({ length: 10 }, (_, i) => createMockFileEntry(`a${i}.txt`))
+    )
+    const dir2 = createMockDirEntry(
+      'dir2',
+      Array.from({ length: 15 }, (_, i) => createMockFileEntry(`b${i}.txt`))
+    )
+    const entries = [
+      { file: null, isDirectory: true, entry: dir1 },
+      { file: null, isDirectory: true, entry: dir2 },
+      { file: new File([''], 'root.txt'), isDirectory: false, entry: null }
+    ]
+    expect(await exceedsFileLimit(entries, 500)).toBe(false)
+  })
+
+  it('should return true when cumulative count across directories exceeds the limit', async () => {
+    const dir1 = createMockDirEntry(
+      'dir1',
+      Array.from({ length: 300 }, (_, i) => createMockFileEntry(`a${i}.txt`))
+    )
+    const dir2 = createMockDirEntry(
+      'dir2',
+      Array.from({ length: 300 }, (_, i) => createMockFileEntry(`b${i}.txt`))
+    )
+    const entries = [
+      { file: null, isDirectory: true, entry: dir1 },
+      { file: null, isDirectory: true, entry: dir2 }
+    ]
+    expect(await exceedsFileLimit(entries, 500)).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

- Uploading large numbers of files via the web silently fails after several minutes due to browser limitations (stale file references, tab switching, sleep, network drops). A technical fix landed in beta but the web path remains fragile for bulk uploads.
- Before starting the upload, all files are now counted (recursively for dropped folders). If the count reaches the configured limit, a dialog warns the user and suggests downloading the desktop sync tool instead.
- The limit defaults to 500 and can be overridden via the `drive.max-upload-file-count` flag.
- The "Download on Desktop" button is hidden on public share links where the desktop app is not available.
- The download link is controlled by the existing `cozy.desktop-app-download-link` flag, falling back to a platform-aware default URL.


https://github.com/user-attachments/assets/8773998d-cf61-47c6-b612-924172b974bd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced a maximum upload limit (default 500 files per upload); uploads that exceed the limit are blocked and show a localized upload-limit dialog with actions including “Download on Desktop” when available.
* **Tests**
  * Added coverage for the upload flow, entry extraction, recursive directory counting, and limit-handling behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->