### PR TITLE
fix: update French wording for upload limit dialog

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -357,10 +357,10 @@
       "fileTooLargeErrors": "Fichier trop volumineux. Taille maximale autorisée par fichier : %{max_size_value} Go"
     },
     "limit": {
-      "title": "Vous ne pouvez pas importer plus de %{limit} fichiers à la fois.",
-      "content": "Besoin d'en importer davantage\u00a0? Téléchargez l'outil de synchronisation sur votre ordinateur",
+      "title": "Importation impossible : Ce dossier contient plus de %{limit} fichiers",
+      "content": "Pour une importation de cette taille, nous vous recommandons d'utiliser l'application de synchronisation sur ordinateur.",
       "cancel": "Annuler",
-      "download_desktop": "Télécharger sur ordinateur"
+      "download_desktop": "Installer l'application"
     }
   },
   "intents": {


### PR DESCRIPTION
## Summary

- Reword the French upload limit dialog to be clearer about why the upload is blocked and what the user should do instead
- Update the desktop app button label from "Télécharger sur ordinateur" to "Installer l'application"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated French error messages for file import limits, clarifying the limitation and recommending the desktop application as an alternative for handling large-scale imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->