### PR TITLE
fix: adapt upload limit dialog for public shared links

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -362,7 +362,9 @@
     "limit": {
       "title": "You cannot upload more than %{limit} files at a time.",
       "content": "Need to upload more? Consider downloading the synchronization tool to your computer",
+      "content_public": "Please reduce the number of files and try again.",
       "cancel": "Cancel",
+      "close": "Close",
       "download_desktop": "Download on Desktop"
     }
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -359,7 +359,9 @@
     "limit": {
       "title": "Importation impossible : Ce dossier contient plus de %{limit} fichiers",
       "content": "Pour une importation de cette taille, nous vous recommandons d'utiliser l'application de synchronisation sur ordinateur.",
+      "content_public": "Veuillez réduire le nombre de fichiers et réessayer.",
       "cancel": "Annuler",
+      "close": "Fermer",
       "download_desktop": "Installer l'application"
     }
   },

--- a/src/modules/upload/UploadLimitDialog.jsx
+++ b/src/modules/upload/UploadLimitDialog.jsx
@@ -25,22 +25,28 @@ const UploadLimitDialog = ({ onClose, maxFileCount }) => {
       open
       onClose={onClose}
       title={t('upload.limit.title', { limit: maxFileCount })}
-      content={<Typography>{t('upload.limit.content')}</Typography>}
+      content={
+        <Typography>
+          {t(isPublic ? 'upload.limit.content_public' : 'upload.limit.content')}
+        </Typography>
+      }
       actions={
-        <>
-          <Button
-            variant="secondary"
-            onClick={onClose}
-            label={t('upload.limit.cancel')}
-          />
-          {!isPublic && (
+        isPublic ? (
+          <Button onClick={onClose} label={t('upload.limit.close')} />
+        ) : (
+          <>
+            <Button
+              variant="secondary"
+              onClick={onClose}
+              label={t('upload.limit.cancel')}
+            />
             <Button
               onClick={handleDownloadDesktop}
               label={t('upload.limit.download_desktop')}
               startIcon={<Icon icon={DesktopDownloadIcon} />}
             />
-          )}
-        </>
+          </>
+        )
       }
     />
   )


### PR DESCRIPTION
## Summary

- On public shared links, the upload limit dialog was suggesting to download the desktop sync app, which makes no sense since the user is not logged in and shared links are not accessible from the desktop app
- Show a simpler message asking to reduce the number of files, with just a "Close" button instead of "Cancel" + "Download on Desktop"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved upload-limit messaging advising users to reduce file count and retry.
  * Context-aware upload dialog actions: public uploads show a single "Close" action; non-public uploads show "Cancel" and "Download for desktop".
  * Added localized strings for the new message and the "Close" label in English and French.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->