### PR TITLE
feat: Sidebar relooking

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,11 +1,11 @@
 {
   "Nav": {
-    "item_drive": "Files",
-    "item_recent": "Recent",
+    "item_drive": "My Drive",
+    "item_recent": "Recents",
     "item_sharings": "Sharings",
     "item_shared": "Shared by me",
     "item_activity": "Activity",
-    "item_trash": "Trash",
+    "item_trash": "Bin",
     "item_settings": "Settings",
     "item_collect": "Administrative",
     "item_shared_drives": "Shared drives",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,6 +1,6 @@
 {
   "Nav": {
-    "item_drive": "Fichiers",
+    "item_drive": "Mon Drive",
     "item_recent": "Récents",
     "item_sharings": "Partages",
     "item_shared": "Partagés",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,6 +1,6 @@
 {
   "Nav": {
-    "item_drive": "Файлы",
+    "item_drive": "Мой диск",
     "item_recent": "Недавние",
     "item_sharings": "Общие",
     "item_shared": "Мои отправленные файлы",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1,6 +1,6 @@
 {
   "Nav": {
-    "item_drive": "Tệp",
+    "item_drive": "Ổ đĩa của tôi",
     "item_recent": "Gần đây",
     "item_sharings": "Chia sẻ",
     "item_shared": "Chia sẻ bởi tôi",

--- a/src/modules/navigation/FavoriteListItem.tsx
+++ b/src/modules/navigation/FavoriteListItem.tsx
@@ -50,7 +50,12 @@ const FavoriteListItem: FC<FavoriteListItemProps> = ({
         onClick={(): void => setLastClicked(undefined)}
       >
         <NavIcon icon={ItemIcon} />
-        <Typography variant="inherit" color="inherit" noWrap>
+        <Typography
+          className="u-fz-small"
+          variant="inherit"
+          color="inherit"
+          noWrap
+        >
           {filename}
         </Typography>
       </FileLink>

--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import ClockIcon from 'cozy-ui/transpiled/react/Icons/Clock'
-import FolderIcon from 'cozy-ui/transpiled/react/Icons/Folder'
+import ClockIcon from 'cozy-ui/transpiled/react/Icons/ClockOutline'
+import CloudIcon from 'cozy-ui/transpiled/react/Icons/Cloud2'
 import StarIcon from 'cozy-ui/transpiled/react/Icons/Star'
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import UINav from 'cozy-ui/transpiled/react/Nav'
@@ -22,7 +22,7 @@ export const Nav = () => {
     <UINav>
       <NavItem
         to="/folder"
-        icon={<Icon icon={FolderIcon} />}
+        icon={<Icon icon={CloudIcon} />}
         label="drive"
         rx={/\/(folder|nextcloud)(\/.*)?/}
         clickState={clickState}

--- a/src/modules/views/useUpdateDocumentTitle.spec.js
+++ b/src/modules/views/useUpdateDocumentTitle.spec.js
@@ -50,13 +50,13 @@ describe('makeTitle', () => {
           'Cozy Drive',
           t
         )
-      ).toBe('file.docx (Trash/folder) - Cozy Drive')
+      ).toBe('file.docx (Bin/folder) - Cozy Drive')
     })
 
     it('should show trash folder with human frendly name even if no subdirectory', () => {
       expect(
         makeTitle({ name: 'file.docx', path: TRASH_DIR_PATH }, 'Cozy Drive', t)
-      ).toBe('file.docx (Trash) - Cozy Drive')
+      ).toBe('file.docx (Bin) - Cozy Drive')
     })
   })
 
@@ -68,7 +68,7 @@ describe('makeTitle', () => {
           'Cozy Drive',
           t
         )
-      ).toBe('Trash - Cozy Drive')
+      ).toBe('Bin - Cozy Drive')
     })
 
     it('should show trash folder with human frendly name', () => {
@@ -82,7 +82,7 @@ describe('makeTitle', () => {
           'Cozy Drive',
           t
         )
-      ).toBe('folder (Trash/folder) - Cozy Drive')
+      ).toBe('folder (Bin/folder) - Cozy Drive')
     })
 
     it('should show folder path and app name', () => {


### PR DESCRIPTION

<img width="259" height="572" alt="Capture d’écran du 2026-04-08 15-58-18" src="https://github.com/user-attachments/assets/c6f3b56a-dec4-4104-ae03-de466bae0037" />


https://www.notion.so/linagora/Sidebar-design-changes-33062718bad1809697d4e0758874cb28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated navigation labels across locales for clearer wording (EN: "My Drive", "Recents", "Bin"; FR: "Mon Drive"; RU: "Мой диск"; VI: "Ổ đĩa của tôi").

* **Style**
  * Replaced the drive/folder navigation icon for a refreshed look.
  * Slightly reduced filename text size in favorites for improved visual hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->