### PR TITLE
feat: tune link sharing flow via cozy-sharing props

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "cozy-pouch-link": "^60.19.0",
     "cozy-realtime": "^5.8.0",
     "cozy-search": "^0.25.3",
-    "cozy-sharing": "^30.1.1",
+    "cozy-sharing": "^30.2.0",
     "cozy-stack-client": "^60.23.0",
     "cozy-ui": "^138.6.0",
     "cozy-ui-plus": "^7.0.0",

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -29,4 +29,6 @@ const flagsList = () => {
   flag('drive.hide-nextcloud-dev')
   flag('drive.keyboard-shortcuts.enabled', true)
   flag('drive.highlight-new-items.enabled', true)
+  flag('sharing.auto-open-settings.enabled')
+  flag('sharing.generate-link-button.enabled')
 }

--- a/src/modules/views/Modal/ShareDisplayedFolderView.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import flag from 'cozy-flags'
 import { ShareModal } from 'cozy-sharing'
 
 import { SHARING_TAB_DRIVES } from '@/constants/config'
@@ -28,6 +29,8 @@ const ShareDisplayedFolderView = () => {
         sharingDesc={displayedFolder.name}
         onClose={onClose}
         onRevokeSuccess={onRevokeSuccess}
+        autoOpenShareRestriction={flag('sharing.auto-open-settings.enabled')}
+        showGenerateLinkButton={flag('sharing.generate-link-button.enabled')}
       />
     )
   }

--- a/src/modules/views/Modal/ShareFileView.jsx
+++ b/src/modules/views/Modal/ShareFileView.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
+import flag from 'cozy-flags'
 import { ShareModal } from 'cozy-sharing'
 
 import { LoaderModal } from '@/components/LoaderModal'
@@ -31,6 +32,8 @@ const ShareFileView = () => {
         documentType="Files"
         sharingDesc={fileResult.data.name}
         onClose={handleExit}
+        autoOpenShareRestriction={flag('sharing.auto-open-settings.enabled')}
+        showGenerateLinkButton={flag('sharing.generate-link-button.enabled')}
       />
     )
   }

--- a/src/modules/views/OnlyOffice/Toolbar/Sharing.jsx
+++ b/src/modules/views/OnlyOffice/Toolbar/Sharing.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
+import flag from 'cozy-flags'
 import { ShareButton, ShareModal, SharedRecipients } from 'cozy-sharing'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
@@ -45,6 +46,8 @@ const Sharing = ({ file }) => {
           documentType="Files"
           sharingDesc={file.name}
           onClose={toggleShareModal}
+          autoOpenShareRestriction={flag('sharing.auto-open-settings.enabled')}
+          showGenerateLinkButton={flag('sharing.generate-link-button.enabled')}
         />
       )}
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7138,10 +7138,10 @@ cozy-search@^0.25.3:
     react-type-animation "3.2.0"
     rooks "7.14.1"
 
-cozy-sharing@^30.1.1:
-  version "30.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-30.1.1.tgz#40dd50be5a98fe819e4d38718e25fd43fbe955b0"
-  integrity sha512-CfDyoJKYVah86bR94+/cNtTfbue2L/Uwcehc12tMuIxM6pQgy2Q5SAzz8KkUgGbdMcU/NBrjeV5d+d+nl+U9FQ==
+cozy-sharing@^30.2.0:
+  version "30.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-sharing/-/cozy-sharing-30.2.0.tgz#bdbb72a7877e7fe17af98e12a45f83e44b849d99"
+  integrity sha512-3pazgGqwDPqwCRZlhQr3MMuZ5d/zl2qhMFxseRSbHc5XMFE1/HqZ2SUNWBpLvlP3E6i9J+Zi4dSFrzStU20lgw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     classnames "^2.5.1"
@@ -12551,9 +12551,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
## Summary

- Picks up cozy-sharing 30.2.0, which exposes the new link sharing flow as props.
- Adds two flags, `sharing.auto-open-settings.enabled` and `sharing.generate-link-button.enabled`, to drive those props so we can gate the rollout from the app.
- Registers both in the dev switcher.