### PR TITLE
fix: show unreadable-files alert for notfounderror during upload

### DIFF
--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -138,6 +138,7 @@ export const uploadFiles =
           conflicts,
           networkErrors,
           errors,
+          unreadableErrors,
           updatedItems,
           fileTooLargeErrors
         }) => {
@@ -148,6 +149,7 @@ export const uploadFiles =
               conflicts,
               networkErrors,
               errors,
+              unreadableErrors,
               updatedItems,
               showAlert,
               t,
@@ -174,6 +176,7 @@ const uploadQueueProcessed =
     conflicts,
     networkErrors,
     errors,
+    unreadableErrors,
     updated,
     showAlert,
     t,
@@ -210,6 +213,7 @@ const uploadQueueProcessed =
         status: f.status,
         message: f.message
       })),
+      unreadableErrors: unreadableErrors.map(f => f.name),
       fileTooLargeErrors: fileTooLargeErrors.map(f => f.name),
       navigateAfterUpload
     })
@@ -223,6 +227,14 @@ const uploadQueueProcessed =
       logger.warn(`Upload module triggers a network error: ${networkErrors}`)
       showAlert({
         message: t('upload.alert.network'),
+        severity: 'secondary'
+      })
+    } else if (unreadableErrors.length > 0) {
+      logger.warn(
+        `Upload module triggers an unreadable files error: ${unreadableErrors}`
+      )
+      showAlert({
+        message: t('upload.alert.unreadable_files'),
         severity: 'secondary'
       })
     } else if (errors.length > 0) {

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -30,11 +30,12 @@ const FAILED = 'failed'
 const CONFLICT = 'conflict'
 const QUOTA = 'quota'
 const NETWORK = 'network'
+const UNREADABLE = 'unreadable'
 const ERR_MAX_FILE_SIZE =
   'The file is too big and exceeds the filesystem maximum file size' // ErrMaxFileSize is used when a file is larger than the filesystem's maximum file size
 
 const DONE_STATUSES = [CREATED, UPDATED]
-const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA]
+const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA, UNREADABLE]
 
 export const status = {
   CANCEL,
@@ -46,6 +47,7 @@ export const status = {
   CONFLICT,
   QUOTA,
   NETWORK,
+  UNREADABLE,
   DONE_STATUSES,
   ERROR_STATUSES,
   ERR_MAX_FILE_SIZE
@@ -288,7 +290,10 @@ export const processNextFile =
 
         // Determine the status based on the error details
         let status
-        if (error.message?.includes(ERR_MAX_FILE_SIZE)) {
+        if (error.name === 'NotFoundError') {
+          // Browser FileSystem API couldn't resolve the entry — typically path exceeds OS limit (Windows MAX_PATH=260) or folder was modified mid-transfer.
+          status = UNREADABLE
+        } else if (error.message?.includes(ERR_MAX_FILE_SIZE)) {
           status = ERR_MAX_FILE_SIZE // File size exceeded maximum size allowed by the server
         } else if (error.status in statusError) {
           status = statusError[error.status]
@@ -550,6 +555,7 @@ export const onQueueEmpty = callback => (dispatch, getState) => {
   const updated = getUpdated(queue)
   const networkErrors = getNetworkErrors(queue)
   const errors = getErrors(queue)
+  const unreadableErrors = getUnreadableErrors(queue)
   const fileTooLargeErrors = getfileTooLargeErrors(queue)
 
   // Extract complete uploaded items (with _id) from the queue
@@ -566,6 +572,7 @@ export const onQueueEmpty = callback => (dispatch, getState) => {
     conflicts,
     networkErrors,
     errors,
+    unreadableErrors,
     updatedItems,
     fileTooLargeErrors
   })
@@ -577,6 +584,7 @@ const getConflicts = queue => filterByStatus(queue, CONFLICT)
 const getErrors = queue => filterByStatus(queue, FAILED)
 const getQuotaErrors = queue => filterByStatus(queue, QUOTA)
 const getNetworkErrors = queue => filterByStatus(queue, NETWORK)
+const getUnreadableErrors = queue => filterByStatus(queue, UNREADABLE)
 const getCreated = queue => filterByStatus(queue, CREATED)
 const getUpdated = queue => filterByStatus(queue, UPDATED)
 const getfileTooLargeErrors = queue => filterByStatus(queue, ERR_MAX_FILE_SIZE)
@@ -596,6 +604,7 @@ export const selectors = {
   getErrors,
   getQuotaErrors,
   getNetworkErrors,
+  getUnreadableErrors,
   getCreated,
   getUpdated,
   getProcessed,

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -74,6 +74,7 @@ describe('processNextFile function', () => {
       conflicts: [],
       networkErrors: [],
       errors: [],
+      unreadableErrors: [],
       updatedItems: [],
       fileTooLargeErrors: []
     })
@@ -262,6 +263,43 @@ describe('processNextFile function', () => {
     expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
       file,
       status: 'quota',
+      type: 'RECEIVE_UPLOAD_ERROR'
+    })
+  })
+
+  it('should classify NotFoundError (browser FileSystem API) as unreadable', async () => {
+    logger.warn = jest.fn()
+    const getState = () => ({
+      upload: {
+        queue: [
+          {
+            status: 'pending',
+            file,
+            entry: '',
+            isDirectory: false
+          }
+        ]
+      }
+    })
+    const notFoundError = new Error(
+      'A requested file or directory could not be found at the time an operation was processed.'
+    )
+    notFoundError.name = 'NotFoundError'
+    createFileSpy.mockRejectedValue(notFoundError)
+
+    const asyncProcess = processNextFile(
+      fileUploadedCallbackSpy,
+      queueCompletedCallbackSpy,
+      dirId,
+      sharingState,
+      { client: fakeClient, vaultClient: fakeVaultClient }
+    )
+    await asyncProcess(dispatchSpy, getState, { client: fakeClient })
+
+    expect(fileUploadedCallbackSpy).not.toHaveBeenCalled()
+    expect(dispatchSpy).toHaveBeenNthCalledWith(2, {
+      file,
+      status: 'unreadable',
       type: 'RECEIVE_UPLOAD_ERROR'
     })
   })


### PR DESCRIPTION
## Summary

- Dragging a folder with a path longer than the OS allows (Windows `MAX_PATH=260` is the common trigger) made the browser FileSystem API throw `NotFoundError` mid-upload. Users saw the generic *"Errors occurred during the upload"* alert instead of the already-translated *"file path may be too long or folder was modified"* one.
- A `NotFoundError` catch already existed in `uploadFiles`, but it only guarded the pre-upload file-count step (`exceedsFileLimit`). Once counting succeeded, the same error raised inside `processNextFile` hit an error classifier that had no branch for it and was bucketed as the generic `FAILED` status, routing it back to the generic alert.
- Adds an `UNREADABLE` upload status, classifies `NotFoundError` at the per-file handler, and routes it to the existing `upload.alert.unreadable_files` locale key. Quota, network, and file-too-large paths are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced upload error handling to detect and report unreadable files with a dedicated alert message, providing clearer feedback when file access issues prevent successful uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->