### PR TITLE
refactor: extract classifyUploadError from processNextFile

### DIFF
--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -55,6 +55,24 @@ export const status = {
 
 const CONFLICT_ERROR = 409
 
+const HTTP_ERROR_STATUS_MAP = {
+  409: CONFLICT,
+  413: QUOTA
+}
+
+export const classifyUploadError = error => {
+  if (error.name === 'NotFoundError') {
+    // Browser FileSystem API couldn't resolve the entry — typically path exceeds OS limit (Windows MAX_PATH=260) or folder was modified mid-transfer.
+    return UNREADABLE
+  }
+  if (error.message?.includes(ERR_MAX_FILE_SIZE)) return ERR_MAX_FILE_SIZE
+  if (error.status in HTTP_ERROR_STATUS_MAP) {
+    return HTTP_ERROR_STATUS_MAP[error.status]
+  }
+  if (/Failed to fetch$/.exec(error.toString())) return NETWORK
+  return FAILED
+}
+
 const itemInitialState = item => ({
   ...item,
   status: PENDING,
@@ -281,30 +299,11 @@ export const processNextFile =
         logger.error(
           `Upload module catches an error when executing processNextFile(): ${error}`
         )
-
-        // Define mapping for specific status codes to our constants
-        const statusError = {
-          409: CONFLICT,
-          413: QUOTA
-        }
-
-        // Determine the status based on the error details
-        let status
-        if (error.name === 'NotFoundError') {
-          // Browser FileSystem API couldn't resolve the entry — typically path exceeds OS limit (Windows MAX_PATH=260) or folder was modified mid-transfer.
-          status = UNREADABLE
-        } else if (error.message?.includes(ERR_MAX_FILE_SIZE)) {
-          status = ERR_MAX_FILE_SIZE // File size exceeded maximum size allowed by the server
-        } else if (error.status in statusError) {
-          status = statusError[error.status]
-        } else if (/Failed to fetch$/.exec(error.toString())) {
-          status = NETWORK
-        } else {
-          status = FAILED
-        }
-
-        // Dispatch an action to handle the upload error with the determined status
-        dispatch({ type: RECEIVE_UPLOAD_ERROR, file, status })
+        dispatch({
+          type: RECEIVE_UPLOAD_ERROR,
+          file,
+          status: classifyUploadError(error)
+        })
       }
     }
     dispatch(

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -5,7 +5,8 @@ import {
   overwriteFile,
   uploadProgress,
   extractFilesEntries,
-  exceedsFileLimit
+  exceedsFileLimit,
+  classifyUploadError
 } from './index'
 
 import { getEncryptionKeyFromDirId } from '@/lib/encryption'
@@ -302,6 +303,42 @@ describe('processNextFile function', () => {
       status: 'unreadable',
       type: 'RECEIVE_UPLOAD_ERROR'
     })
+  })
+})
+
+describe('classifyUploadError', () => {
+  it('returns UNREADABLE for a browser NotFoundError', () => {
+    const error = new Error('A requested file or directory could not be found.')
+    error.name = 'NotFoundError'
+    expect(classifyUploadError(error)).toBe('unreadable')
+  })
+
+  it('returns the ERR_MAX_FILE_SIZE status when the message matches', () => {
+    const error = new Error(
+      'The file is too big and exceeds the filesystem maximum file size'
+    )
+    expect(classifyUploadError(error)).toBe(
+      'The file is too big and exceeds the filesystem maximum file size'
+    )
+  })
+
+  it('maps HTTP 409 to CONFLICT', () => {
+    expect(classifyUploadError({ status: 409 })).toBe('conflict')
+  })
+
+  it('maps HTTP 413 to QUOTA', () => {
+    expect(classifyUploadError({ status: 413 })).toBe('quota')
+  })
+
+  it('returns NETWORK when the error ends with "Failed to fetch"', () => {
+    expect(classifyUploadError(new TypeError('Failed to fetch'))).toBe(
+      'network'
+    )
+  })
+
+  it('falls back to FAILED for unrecognized errors', () => {
+    expect(classifyUploadError(new Error('something else'))).toBe('failed')
+    expect(classifyUploadError({ status: 500 })).toBe('failed')
   })
 })
 


### PR DESCRIPTION
## Summary

- `processNextFile` mixed upload orchestration with error classification, showing up as a Complex Method hotspot in CodeScene. Extracting the classifier as a pure, exported `classifyUploadError(error)` removes five decision points from the caller and brings the method back below its previous complexity baseline.
- The HTTP-status map is hoisted to module scope so it's no longer re-allocated on every dispatched error.
- Each classifier branch (`NotFoundError`, `ERR_MAX_FILE_SIZE`, HTTP 409/413, `Failed to fetch`, fallback) now has a direct unit test instead of only being reachable through the full `processNextFile` dispatch path. The existing integration tests stay green, confirming the extraction is behaviour-preserving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved upload error classification logic for consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for upload error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->