### PR TITLE
fix: show unreadable-files alert for NotFoundError during upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "cozy-sharing": "^30.2.1",
     "cozy-stack-client": "^60.23.0",
     "cozy-ui": "^138.6.2",
-    "cozy-ui-plus": "^7.0.0",
+    "cozy-ui-plus": "^7.1.0",
     "cozy-viewer": "^28.0.7",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -112,7 +112,7 @@ export const uploadFiles =
       if (error?.name === 'NotFoundError') {
         showAlert({
           message: t('upload.alert.unreadable_files'),
-          severity: 'secondary'
+          severity: 'error'
         })
         return
       }
@@ -235,7 +235,7 @@ const uploadQueueProcessed =
       )
       showAlert({
         message: t('upload.alert.unreadable_files'),
-        severity: 'secondary'
+        severity: 'error'
       })
     } else if (errors.length > 0) {
       logger.error(`Upload module triggers an error: ${errors}`)

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -35,7 +35,7 @@ const ERR_MAX_FILE_SIZE =
   'The file is too big and exceeds the filesystem maximum file size' // ErrMaxFileSize is used when a file is larger than the filesystem's maximum file size
 
 const DONE_STATUSES = [CREATED, UPDATED]
-const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA, UNREADABLE]
+const ERROR_STATUSES = [CONFLICT, NETWORK, QUOTA, FAILED, UNREADABLE]
 
 export const status = {
   CANCEL,
@@ -291,7 +291,7 @@ export const processNextFile =
         // Determine the status based on the error details
         let status
         if (error.name === 'NotFoundError') {
-          // Browser FileSystem API couldn't resolve the entry — typically path exceeds OS limit (Windows MAX_PATH=260) or folder was modified mid-transfer.
+          // Browser FileSystem API couldn't resolve the entry — path too long or folder modified mid-transfer.
           status = UNREADABLE
         } else if (error.message?.includes(ERR_MAX_FILE_SIZE)) {
           status = ERR_MAX_FILE_SIZE // File size exceeded maximum size allowed by the server

--- a/yarn.lock
+++ b/yarn.lock
@@ -7185,10 +7185,10 @@ cozy-tsconfig@^1.8.1:
   resolved "https://registry.yarnpkg.com/cozy-tsconfig/-/cozy-tsconfig-1.8.1.tgz#5f206f4e6e041a4afc6691098264ba630bdeb7e2"
   integrity sha512-/9QBxK8Tc12O2ojuyRpSMjPpXpqldVvzfNB1+/nPD+IkIBkU+mqxpHYJwKWjNYHGraCSy69mIwt9J3aiaJdz9w==
 
-cozy-ui-plus@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui-plus/-/cozy-ui-plus-7.0.0.tgz#13c9dcca352a995d130b67f42d4a6699acaada03"
-  integrity sha512-8oMmXyGvs21n2bpcOu9ibbY98MEOxgfmZAa14oMxQQYnBUNuoRadZiODvDOPLpA6SvQX17rXTxsMoDMmVa+0Ng==
+cozy-ui-plus@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui-plus/-/cozy-ui-plus-7.1.0.tgz#b0bf9d1c0b9005e72217691ecc21dfeacacf40ca"
+  integrity sha512-QcUQzCjDkOu2cUWEFvywK++TQhOzQiachJ26JH0nJyh23YDJj/ENgzPSZsxTeE48t3g1Uybzj5Ee0vUk6osP4w==
   dependencies:
     classnames "^2.5.1"
     filesize "8.0.7"
@@ -12551,9 +12551,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
## Summary

- Uploads failing with a long-path `NotFoundError` surfaced the generic *"Errors occurred during the upload"* alert instead of the specific *"file path may be too long or folder was modified"* one. The classifier at `src/modules/upload/index.js` only recognized HTTP 409, 413, `Failed to fetch`, and the file-size overrun message — so these errors fell into the `FAILED` bucket and picked up the wrong toast.
- Adds a dedicated `'unreadable'` upload status, classifies `NotFoundError` into it, and routes it to the already-translated `upload.alert.unreadable_files` key. The toast is shown with severity `'error'` (red banner) instead of `'secondary'` (grey); the pre-upload `exceedsFileLimit` catch path that already surfaced this same message is aligned to the same severity.
- Bumps `cozy-ui-plus` to `^7.1.0` (from https://github.com/linagora/cozy-libs/pull/2991) which recognizes `'unreadable'` as an error status so the queue row renders with the red bar and warning triangle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error alerts for unreadable files during uploads now show error-level severity.
  * Error classification expanded to include additional failed upload scenarios for more accurate handling.

* **Chores**
  * Updated UI dependency to a newer patch/minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->