### PR TITLE
feat: Replace Migration action with migration section

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,7 +24,8 @@
     "link-client-ios": "https://apps.apple.com/app/cloud-personnel-cozy/id1600636174",
     "link-client-web": "https://cozy.io/try-it",
     "view_more": "View more",
-    "view_less": "View less"
+    "view_less": "View less",
+    "item_nextcloud": "Nextcloud"
   },
   "breadcrumb": {
     "title_drive": "Files",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -24,7 +24,8 @@
     "link-client-ios": "https://apps.apple.com/app/cloud-personnel-cozy/id1600636174",
     "link-client-web": "https://cozy.io/try-it",
     "view_more": "Voir plus",
-    "view_less": "Voir moins"
+    "view_less": "Voir moins",
+    "item_nextcloud": "Nextcloud"
   },
   "breadcrumb": {
     "title_drive": "Fichiers",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -25,7 +25,8 @@
     "link-client-ios": "https://apps.apple.com/app/cloud-personnel-cozy/id1600636174",
     "link-client-web": "https://cozy.io/try-it",
     "view_more": "Показать больше",
-    "view_less": "Показать меньше"
+    "view_less": "Показать меньше",
+    "item_nextcloud": "Nextcloud"
   },
   "breadcrumb": {
     "title_drive": "Файлы",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -25,7 +25,8 @@
     "link-client-ios": "https://apps.apple.com/app/cloud-personnel-cozy/id1600636174",
     "link-client-web": "https://cozy.io/try-it",
     "view_more": "Hiển thị thêm",
-    "view_less": "Hiển thị ít hơn"
+    "view_less": "Hiển thị ít hơn",
+    "item_nextcloud": "Nextcloud"
   },
   "breadcrumb": {
     "title_drive": "Tệp",

--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -4,12 +4,14 @@ import flag from 'cozy-flags'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import ClockIcon from 'cozy-ui/transpiled/react/Icons/ClockOutline'
 import CloudIcon from 'cozy-ui/transpiled/react/Icons/Cloud2'
-import CloudSyncIcon from 'cozy-ui/transpiled/react/Icons/CloudSync'
 import StarIcon from 'cozy-ui/transpiled/react/Icons/Star'
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import { NavDesktopDropdown } from 'cozy-ui/transpiled/react/Nav'
 import UINav from 'cozy-ui/transpiled/react/Nav'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
 
+import NextcloudIcon from '@/assets/icons/icon-nextcloud.svg'
 import { ExternalNavItem } from '@/modules/navigation/ExternalNavItem'
 import { FavoriteList } from '@/modules/navigation/FavoriteList'
 import { useNavContext } from '@/modules/navigation/NavContext'
@@ -20,6 +22,7 @@ import { ExternalDrives } from '@/modules/navigation/components/ExternalDrivesLi
 export const Nav = () => {
   const clickState = useNavContext()
   const { isDesktop } = useBreakpoints()
+  const { t } = useI18n()
 
   return (
     <UINav>
@@ -55,13 +58,15 @@ export const Nav = () => {
         clickState={clickState}
       />
       {flag('settings.migration.enabled') && (
-        <ExternalNavItem
-          slug="settings"
-          icon={<Icon icon={CloudSyncIcon} />}
-          label="migration"
-          path="/migration"
-          clickState={clickState}
-        />
+        <NavDesktopDropdown label={t('Nav.item_migration')} limit={0}>
+          <ExternalNavItem
+            slug="settings"
+            icon={<Icon icon={NextcloudIcon} />}
+            label="nextcloud"
+            path="/migration"
+            clickState={clickState}
+          />
+        </NavDesktopDropdown>
       )}
       {isDesktop ? <FavoriteList clickState={clickState} /> : null}
       {isDesktop ? (


### PR DESCRIPTION
With a nextcloud action

<img width="232" height="124" alt="image" src="https://github.com/user-attachments/assets/99efff5b-6016-4808-9711-f56aba37e073" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nextcloud navigation item visible in the main navigation, including English, French, Russian, and Vietnamese translations; the item now appears in the desktop navigation dropdown when the migration feature is enabled and shows the Nextcloud icon and label.
* **Bug Fixes**
  * Fixed localization JSON formatting to ensure translations load correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->