### PR TITLE
feat(navigation): Add flagged new sidebar components

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "cozy-search": "^0.25.3",
     "cozy-sharing": "^30.3.1",
     "cozy-stack-client": "^60.23.0",
-    "cozy-ui": "^138.6.2",
+    "cozy-ui": "^138.7.0",
     "cozy-ui-plus": "^7.1.0",
     "cozy-viewer": "^28.0.7",
     "date-fns": "2.30.0",

--- a/src/modules/navigation/ExternalNavItem.jsx
+++ b/src/modules/navigation/ExternalNavItem.jsx
@@ -4,17 +4,15 @@ import React, { useCallback } from 'react'
 import { useClient, generateWebLink } from 'cozy-client'
 import { isFlagshipApp } from 'cozy-device-helper'
 import { useWebviewIntent } from 'cozy-intent'
-import {
-  NavLink as UINavLink,
-  NavItem as UINavItem
-} from 'cozy-ui/transpiled/react/Nav'
 import { useI18n } from 'twake-i18n'
 
 import { NavContent } from '@/modules/navigation/NavContent'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 
 const ExternalNavItem = ({ slug, icon, label, path, clickState }) => {
   const { t } = useI18n()
   const client = useClient()
+  const { NavLink: UINavLink, NavItem: UINavItem } = getNavComponents()
   const webviewIntent = useWebviewIntent()
 
   const href = generateWebLink({

--- a/src/modules/navigation/FavoriteList.tsx
+++ b/src/modules/navigation/FavoriteList.tsx
@@ -2,10 +2,10 @@ import React, { FC } from 'react'
 
 import { useQuery } from 'cozy-client'
 import { IOCozyFile } from 'cozy-client/types/types'
-import { NavDesktopDropdown } from 'cozy-ui/transpiled/react/Nav'
 import { useI18n } from 'twake-i18n'
 
 import { FavoriteListItem } from '@/modules/navigation/FavoriteListItem'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 import { buildFavoritesQuery } from '@/queries'
 
 interface FavoriteListProps {
@@ -14,6 +14,7 @@ interface FavoriteListProps {
 
 const FavoriteList: FC<FavoriteListProps> = ({ clickState }) => {
   const { t } = useI18n()
+  const { NavDesktopDropdown } = getNavComponents()
   const favoritesQuery = buildFavoritesQuery({
     sortAttribute: 'name',
     sortOrder: 'desc'

--- a/src/modules/navigation/FavoriteListItem.tsx
+++ b/src/modules/navigation/FavoriteListItem.tsx
@@ -10,12 +10,12 @@ import type { IOCozyFile } from 'cozy-client/types/types'
 import FileIcon from 'cozy-ui/transpiled/react/Icons/File'
 import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
 import FolderIcon from 'cozy-ui/transpiled/react/Icons/Folder'
-import { NavIcon, NavLink, NavItem } from 'cozy-ui/transpiled/react/Nav'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { FileLink } from './components/FileLink'
 
 import { useFileLink } from '@/modules/navigation/hooks/useFileLink'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 import { isNextcloudShortcut } from '@/modules/nextcloud/helpers'
 
 interface FavoriteListItemProps {
@@ -35,6 +35,7 @@ const FavoriteListItem: FC<FavoriteListItemProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   clickState: [lastClicked, setLastClicked]
 }) => {
+  const { NavIcon, NavLink, NavItem } = getNavComponents()
   const { link } = useFileLink(file, {
     forceFolderPath: isNote(file) || isOnlyOfficeFile(file) ? false : true
   })

--- a/src/modules/navigation/Nav.jsx
+++ b/src/modules/navigation/Nav.jsx
@@ -7,7 +7,6 @@ import CloudIcon from 'cozy-ui/transpiled/react/Icons/Cloud2'
 import CloudSyncIcon from 'cozy-ui/transpiled/react/Icons/CloudSync'
 import StarIcon from 'cozy-ui/transpiled/react/Icons/Star'
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
-import UINav from 'cozy-ui/transpiled/react/Nav'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
 import { ExternalNavItem } from '@/modules/navigation/ExternalNavItem'
@@ -16,13 +15,15 @@ import { useNavContext } from '@/modules/navigation/NavContext'
 import { NavItem } from '@/modules/navigation/NavItem'
 import { SharingsNavItem } from '@/modules/navigation/SharingsNavItem'
 import { ExternalDrives } from '@/modules/navigation/components/ExternalDrivesList'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 
 export const Nav = () => {
   const clickState = useNavContext()
   const { isDesktop } = useBreakpoints()
+  const { Nav: NavComponent } = getNavComponents()
 
   return (
-    <UINav>
+    <NavComponent>
       <NavItem
         to="/folder"
         icon={<Icon icon={CloudIcon} />}
@@ -67,7 +68,7 @@ export const Nav = () => {
       {isDesktop ? (
         <ExternalDrives clickState={clickState} className="u-mt-half" />
       ) : null}
-    </UINav>
+    </NavComponent>
   )
 }
 

--- a/src/modules/navigation/NavContent.tsx
+++ b/src/modules/navigation/NavContent.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 
 import Avatar from 'cozy-ui/transpiled/react/Avatar'
 import Badge from 'cozy-ui/transpiled/react/Badge'
-import { NavIcon, NavText } from 'cozy-ui/transpiled/react/Nav'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+
+import { getNavComponents } from '@/modules/navigation/navComponents'
 
 interface NavContentProps {
   icon?: string
@@ -17,6 +18,7 @@ const NavContent: React.FC<NavContentProps> = ({
   label
 }) => {
   const { isDesktop } = useBreakpoints()
+  const { NavIcon, NavText } = getNavComponents()
 
   if (badgeContent) {
     if (isDesktop) {

--- a/src/modules/navigation/NavItem.jsx
+++ b/src/modules/navigation/NavItem.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { NavItem as UINavItem } from 'cozy-ui/transpiled/react/Nav'
 import { useI18n } from 'twake-i18n'
 
 import { NavContent } from '@/modules/navigation/NavContent'
 import { NavLink } from '@/modules/navigation/NavLink'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 
 /**
  * Renders a navigation item with optional badge content and support for shared links.
@@ -33,6 +33,7 @@ const NavItem = ({
   forcedLabel
 }) => {
   const { t } = useI18n()
+  const { NavItem: UINavItem } = getNavComponents()
 
   return (
     <UINavItem secondary={secondary}>

--- a/src/modules/navigation/NavLink.jsx
+++ b/src/modules/navigation/NavLink.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 
-import { NavLink as UINavLink } from 'cozy-ui/transpiled/react/Nav'
-
 import { navLinkMatch } from '@/modules/navigation/helpers'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 
 /**
  * Like react-router NavLink but sets the lastClicked state (passed in props)
@@ -21,6 +20,7 @@ const NavLink = ({
   const location = useLocation()
   const pathname = lastClicked ? lastClicked : location.pathname
   const isActive = navLinkMatch(rx, to, pathname)
+  const { NavLink: UINavLink } = getNavComponents()
   return (
     <a
       style={{ outline: 'none' }}

--- a/src/modules/navigation/components/ExternalDriveListItem.tsx
+++ b/src/modules/navigation/components/ExternalDriveListItem.tsx
@@ -3,12 +3,12 @@ import React, { FC } from 'react'
 import { splitFilename } from 'cozy-client/dist/models/file'
 import type { IOCozyFile } from 'cozy-client/types/types'
 import FileTypeServerIcon from 'cozy-ui/transpiled/react/Icons/FileTypeServer'
-import { NavIcon, NavLink, NavItem } from 'cozy-ui/transpiled/react/Nav'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import { FileLink } from './FileLink'
 
 import { useFileLink } from '@/modules/navigation/hooks/useFileLink'
+import { getNavComponents } from '@/modules/navigation/navComponents'
 
 interface ExternalDriveListItemProps {
   file: IOCozyFile
@@ -19,6 +19,7 @@ const ExternalDriveListItem: FC<ExternalDriveListItemProps> = ({
   file,
   setLastClicked
 }) => {
+  const { NavIcon, NavLink, NavItem } = getNavComponents()
   const { link } = useFileLink(file, { forceFolderPath: false })
   const { filename } = splitFilename(file)
 

--- a/src/modules/navigation/navComponents.ts
+++ b/src/modules/navigation/navComponents.ts
@@ -1,0 +1,42 @@
+import flag from 'cozy-flags'
+import NavOld, {
+  NavDesktopDropdown as NavDesktopDropdownOld,
+  NavIcon as NavIconOld,
+  NavItem as NavItemOld,
+  NavLink as NavLinkOld,
+  NavText as NavTextOld
+} from 'cozy-ui/transpiled/react/Nav'
+import NavNew, {
+  NavDesktopDropdown as NavDesktopDropdownNew,
+  NavIcon as NavIconNew,
+  NavItem as NavItemNew,
+  NavLink as NavLinkNew,
+  NavText as NavTextNew
+} from 'cozy-ui/transpiled/react/NavNext'
+
+type NavComponents = {
+  Nav: typeof NavNew
+  NavDesktopDropdown: typeof NavDesktopDropdownNew
+  NavIcon: typeof NavIconNew
+  NavItem: typeof NavItemNew
+  NavLink: typeof NavLinkNew
+  NavText: typeof NavTextNew
+}
+
+const isNewSidebarEnabled = (): boolean =>
+  Boolean(flag('drive.new-sidebar.enabled'))
+
+export const getNavComponents = (): NavComponents => {
+  const useNewSidebar = isNewSidebarEnabled()
+
+  return {
+    Nav: useNewSidebar ? NavNew : (NavOld as typeof NavNew),
+    NavDesktopDropdown: useNewSidebar
+      ? NavDesktopDropdownNew
+      : (NavDesktopDropdownOld as typeof NavDesktopDropdownNew),
+    NavIcon: useNewSidebar ? NavIconNew : (NavIconOld as typeof NavIconNew),
+    NavItem: useNewSidebar ? NavItemNew : (NavItemOld as typeof NavItemNew),
+    NavLink: useNewSidebar ? NavLinkNew : (NavLinkOld as typeof NavLinkNew),
+    NavText: useNewSidebar ? NavTextNew : (NavTextOld as typeof NavTextNew)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7201,10 +7201,10 @@ cozy-ui-plus@^7.1.0:
     react-international-phone "4.7.0"
     rooks "7.14.1"
 
-cozy-ui@^138.6.2:
-  version "138.6.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-138.6.2.tgz#40ce17aa2405d83369f6b5cf795285c9465b0b6b"
-  integrity sha512-dMsJceDLNnGrQ2tiYWK6n6DXEFYzA67P7AUgMD/KCrO9/qNQoEVcVYK4wC6kCeTDf7Wabpywr79Zp8+BYP2AFg==
+cozy-ui@^138.7.0:
+  version "138.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-138.7.0.tgz#353ddeb5c56386132061ff3ee7254f268fba15b1"
+  integrity sha512-nXqRiWL61WrZhGg9X5qadZVmSwhy88O0GG3JMJkCUkejPUkERiYA0LR3YW30ZtyEsBu0hE/qY764D36IHXmhtg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@date-io/date-fns" "1"


### PR DESCRIPTION
Had to centralise the fetching of Nav/NavNext components to avoid to duplicate the flag and component choosing logic

<img width="244" height="295" alt="image" src="https://github.com/user-attachments/assets/564347e7-8632-4eac-8a97-81d651aca075" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Navigation system refactored to support dynamic component resolution, enabling seamless switching between sidebar UI variants through a feature flag.

* **Chores**
  * Updated cozy-ui dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->