### PR TITLE
feat: keep upload errors visible and styled as errors

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -41,6 +41,7 @@ declare module 'cozy-ui/transpiled/react/providers/Alert' {
       | 'warning'
       | 'info'
     action?: React.ReactNode
+    duration?: number | null
   }
 
   export type showAlertFunction = (props: showAlertProps) => void

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -205,7 +205,8 @@ const uploadQueueProcessed =
       logger.warn(`Upload module triggers a network error: ${networkErrors}`)
       showAlert({
         message: t('upload.alert.network'),
-        severity: 'secondary'
+        severity: 'error',
+        duration: null
       })
     } else if (unreadableErrors.length > 0) {
       logger.warn(
@@ -213,13 +214,15 @@ const uploadQueueProcessed =
       )
       showAlert({
         message: t('upload.alert.unreadable_files'),
-        severity: 'error'
+        severity: 'error',
+        duration: null
       })
     } else if (errors.length > 0) {
       logger.error(`Upload module triggers an error: ${errors}`)
       showAlert({
         message: t('upload.alert.errors', { type }),
-        severity: 'secondary'
+        severity: 'error',
+        duration: null
       })
     } else if (updatedCount > 0 && createdCount > 0 && conflictCount > 0) {
       showAlert({
@@ -271,7 +274,8 @@ const uploadQueueProcessed =
         message: t('upload.alert.fileTooLargeErrors', {
           max_size_value: MAX_PAYLOAD_SIZE_IN_GB
         }),
-        severity: 'error'
+        severity: 'error',
+        duration: null
       })
     } else {
       showAlert({

--- a/src/modules/views/Upload/useUploadFromFlagship.ts
+++ b/src/modules/views/Upload/useUploadFromFlagship.ts
@@ -30,6 +30,14 @@ export const useUploadFromFlagship = (): UploadFromFlagship => {
   const { t } = useI18n()
   const { showAlert } = useAlert()
 
+  const showImportError = useCallback(() => {
+    showAlert({
+      message: t('ImportToDrive.error'),
+      severity: 'error',
+      duration: null
+    })
+  }, [showAlert, t])
+
   useEffect(() => {
     const asyncGetFilesToHandle = async (): Promise<void> => {
       if (fromFlagshipUpload && webviewIntent) {
@@ -44,14 +52,14 @@ export const useUploadFromFlagship = (): UploadFromFlagship => {
               error
             )}`
           )
-          showAlert({ message: t('ImportToDrive.error'), severity: 'error' })
+          showImportError()
           navigate('/')
         }
       }
     }
 
     void asyncGetFilesToHandle()
-  }, [fromFlagshipUpload, webviewIntent, navigate, showAlert, t])
+  }, [fromFlagshipUpload, webviewIntent, navigate, showImportError])
 
   const uploadFilesFromFlagship = useCallback(
     (folderId: string) => {
@@ -68,12 +76,12 @@ export const useUploadFromFlagship = (): UploadFromFlagship => {
         sendFilesToHandle(filesForQueue, webviewIntent, folderId)
         navigate(`/folder/${folderId}`)
       } catch (error) {
-        showAlert({ message: t('ImportToDrive.error'), severity: 'error' })
+        showImportError()
         logger('info', `uploadFilesFromNative error, ${getErrorMessage(error)}`)
         navigate('/')
       }
     },
-    [dispatch, items, navigate, t, webviewIntent, showAlert]
+    [dispatch, items, navigate, webviewIntent, showImportError]
   )
 
   const onClose = useCallback(async () => {


### PR DESCRIPTION
## Problem

When an upload fails, the error toast auto-dismisses after 2 seconds. That is often not long enough to read the message, let alone screenshot it for support. Someone dropping a large folder and walking away comes back to no indication of what went wrong.

A second issue made this worse: the network failure and the generic upload error were rendered in the blue "info" style, indistinguishable from success toasts. People could miss the failure entirely.

## Summary

- Upload error alerts stay visible until the user closes them.
- They are styled as errors, not as info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alerts now support an optional display duration value.
* **Bug Fixes**
  * Upload and import error alerts now persist (do not auto-dismiss) and are presented with error severity.
* **Refactor**
  * Alert handling for import failures was consolidated to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->