### PR TITLE
fix: tolerate partial folder reads during upload

### DIFF
--- a/src/modules/upload/UploadQueue.jsx
+++ b/src/modules/upload/UploadQueue.jsx
@@ -13,6 +13,7 @@ import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Paper from 'cozy-ui/transpiled/react/Paper'
+import Tooltip from 'cozy-ui/transpiled/react/Tooltip'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Button from 'cozy-ui/transpiled/react/deprecated/Button'
 import { useI18n } from 'twake-i18n'
@@ -150,13 +151,28 @@ const UploadItem = ({ item, t }) => {
       <ListItemText
         disableTypography
         primary={
-          <Typography
-            variant="body1"
-            className="u-ellipsis"
-            data-testid="upload-queue-item-name"
-          >
-            {displayName}
-          </Typography>
+          // Tooltip only when the row carries a relative path — for
+          // loose top-level files `displayName` is just the bare
+          // filename and the tooltip would duplicate the visible label.
+          relativePath ? (
+            <Tooltip title={displayName} placement="top">
+              <Typography
+                variant="body1"
+                className="u-ellipsis"
+                data-testid="upload-queue-item-name"
+              >
+                {displayName}
+              </Typography>
+            </Tooltip>
+          ) : (
+            <Typography
+              variant="body1"
+              className="u-ellipsis"
+              data-testid="upload-queue-item-name"
+            >
+              {displayName}
+            </Typography>
+          )
         }
         secondary={
           isLoading && item.progress ? (

--- a/src/modules/upload/index.js
+++ b/src/modules/upload/index.js
@@ -523,54 +523,160 @@ const makeFlatItem = (file, folderId, relativePath = null, nonce = '') => {
 }
 
 /**
- * Recursively walk a `FileSystemDirectoryEntry`, creating (or reusing)
- * folders on the server as it goes, and return one flat queue item per
- * contained file.
+ * Build a queue item representing an entry we couldn't read locally.
+ *
+ * The status is preset (via {@link classifyUploadError}) so the reducer
+ * keeps it instead of promoting the row to PENDING. A `NotFoundError`
+ * lands on UNREADABLE (firing the unreadable-files alert downstream);
+ * permission / generic I/O errors land on FAILED rather than being
+ * silently mislabelled. The synthetic `file` shim carries the entry's
+ * display name so the upload tray can render the row even though we
+ * never obtained a real `File` object. `isDirectory` is propagated so
+ * the queue UI renders the folder glyph for unreadable directories,
+ * making them visually distinct from unreadable files.
+ *
+ * @param {string} name - Local entry name (file or folder)
+ * @param {string|null} relativePath - Path of the failed entry relative
+ *   to the drop root (e.g. `"a/b/c/d/e"`), or `null` for top-level
+ *   loose entries
+ * @param {string} nonce - Per-drop nonce, same shape as in {@link makeFlatItem}
+ * @param {Error} error - The rejection from `readEntries` or `entry.file()`
+ * @param {boolean} [isDirectory=false] - `true` when the failed entry
+ *   was a directory (its `readEntries` rejected); `false` for a file
+ *   whose `entry.file()` rejected
+ * @returns {{fileId: string, file: {name: string, type: string},
+ *   relativePath: string|null, folderId: null, status: string,
+ *   isDirectory: boolean}}
+ */
+const makeFailedItem = (
+  name,
+  relativePath,
+  nonce,
+  error,
+  isDirectory = false
+) => {
+  const base = relativePath ?? name
+  return {
+    fileId: nonce ? `${nonce}_${base}` : base,
+    file: { name, type: '' },
+    relativePath,
+    folderId: null,
+    isDirectory,
+    status: classifyUploadError(error)
+  }
+}
+
+/**
+ * @typedef {object} WalkedNode
+ * @property {string} name - Local entry name
+ * @property {true} [readFailed] - Set when `readEntries` rejected; the
+ *   node has no children and `error` carries the rejection
+ * @property {Error} [error] - Present iff `readFailed` is true
+ * @property {File[]} [files] - Successfully extracted `File` objects
+ * @property {Array<{name: string, error: Error}>} [failedFiles] -
+ *   Child file entries whose `entry.file()` rejected
+ * @property {WalkedNode[]} [subdirs] - Recursively-walked subdirectories
+ */
+
+/**
+ * Walk a `FileSystemDirectoryEntry` locally without touching the
+ * server. Read failures (long-path `NotFoundError` on Windows, vanished
+ * entries) are captured per-node instead of thrown, so the materialize
+ * step can finish creating the surrounding tree and surface failed
+ * reads as queue rows.
+ *
+ * Files within a directory are extracted via `Promise.all` (parallel),
+ * matching the original code's concurrency. Subdirs are recursed into
+ * sequentially to keep the parallelism bounded on wide trees.
  *
  * @param {FileSystemDirectoryEntry} dirEntry
- * @param {string} parentDirId - Server id of the enclosing directory
- * @param {object} client - cozy-client instance
- * @param {string} [driveId]
- * @param {string} [pathPrefix] - Relative path accumulated so far
- * @returns {Promise<Array<{fileId: string, file: File, relativePath: string, folderId: string}>>}
+ * @returns {Promise<WalkedNode>}
  */
-const flattenDirectoryEntry = async (
-  dirEntry,
-  parentDirId,
-  client,
-  driveId,
-  pathPrefix = '',
-  nonce = ''
-) => {
-  const newDir = await createFolderOrGetExisting(
-    client,
-    dirEntry.name,
-    parentDirId,
-    driveId
-  )
-  const newPrefix = pathPrefix
-    ? `${pathPrefix}/${dirEntry.name}`
-    : dirEntry.name
-  const childEntries = await readAllEntries(dirEntry.createReader())
-  const fileEntries = childEntries.filter(e => e.isFile)
-  const subdirEntries = childEntries.filter(e => e.isDirectory)
-  const files = await Promise.all(fileEntries.map(getFileFromEntry))
-
-  const result = files.map(file =>
-    makeFlatItem(file, newDir.id, `${newPrefix}/${file.name}`, nonce)
-  )
-  for (const sub of subdirEntries) {
-    const subItems = await flattenDirectoryEntry(
-      sub,
-      newDir.id,
-      client,
-      driveId,
-      newPrefix,
-      nonce
-    )
-    result.push(...subItems)
+const walkDirectoryEntry = async dirEntry => {
+  let childEntries
+  try {
+    childEntries = await readAllEntries(dirEntry.createReader())
+  } catch (error) {
+    return { name: dirEntry.name, readFailed: true, error }
   }
-  return result
+  const fileEntries = childEntries.filter(c => c.isFile)
+  const subdirEntries = childEntries.filter(c => c.isDirectory)
+  const files = []
+  const failedFiles = []
+  const filePromises = fileEntries.map(c =>
+    getFileFromEntry(c).then(
+      f => files.push(f),
+      error => failedFiles.push({ name: c.name, error })
+    )
+  )
+  await Promise.all(filePromises)
+  const subdirs = []
+  for (const sub of subdirEntries) {
+    subdirs.push(await walkDirectoryEntry(sub))
+  }
+  return { name: dirEntry.name, files, failedFiles, subdirs }
+}
+
+/**
+ * @typedef {{fileId: string, file: File, relativePath: string|null, folderId: string}} ReadableFlatItem
+ * @typedef {{fileId: string, file: {name: string, type: string},
+ *   relativePath: string|null, folderId: null, status: string,
+ *   isDirectory: boolean}} FailedFlatItem
+ */
+
+/**
+ * Materialize a walked tree: create the server folder for every node
+ * we visited (including empty ones and ones whose `readEntries` failed
+ * locally), emit a flat queue item per readable file, and emit one
+ * error row per failed read (folder or file).
+ *
+ * Folders are created unconditionally so the resulting tree in Drive
+ * matches the shape that was dropped. Empty folders survive the round
+ * trip; folders whose contents couldn't be read appear empty AND carry
+ * a queue row pointing at the missing subtree so the user can drop the
+ * files back in by hand.
+ *
+ * @param {WalkedNode} node - A node returned by {@link walkDirectoryEntry}
+ * @param {string} parentDirId - Server id of the enclosing directory
+ *   (i.e. the dir into which this node will be created)
+ * @param {string} pathPrefix - Relative path accumulated so far,
+ *   without a trailing slash; `''` at the drop root
+ * @param {{client: object, driveId?: string, nonce: string}} ctx -
+ *   Drop-invariant deps grouped to keep the recursion-changing args
+ *   (`node`, `parentDirId`, `pathPrefix`) positional and short
+ * @returns {Promise<Array<ReadableFlatItem|FailedFlatItem>>}
+ */
+const materializeNode = async (node, parentDirId, pathPrefix, ctx) => {
+  const newPrefix = pathPrefix ? `${pathPrefix}/${node.name}` : node.name
+  const newDir = await createFolderOrGetExisting(
+    ctx.client,
+    node.name,
+    parentDirId,
+    ctx.driveId
+  )
+  if (node.readFailed) {
+    return [makeFailedItem(node.name, newPrefix, ctx.nonce, node.error, true)]
+  }
+
+  const items = node.failedFiles.map(ff =>
+    makeFailedItem(
+      ff.name,
+      `${newPrefix}/${ff.name}`,
+      ctx.nonce,
+      ff.error,
+      false
+    )
+  )
+  for (const file of node.files) {
+    items.push(
+      makeFlatItem(file, newDir.id, `${newPrefix}/${file.name}`, ctx.nonce)
+    )
+  }
+  for (const sub of node.subdirs) {
+    const subItems = await materializeNode(sub, newDir.id, newPrefix, ctx)
+    items.push(...subItems)
+  }
+  return items
 }
 
 /**
@@ -609,7 +715,11 @@ const makeFolderResolver = (rootDirId, client, driveId) => {
  *
  * Three entry shapes are handled in a single pass:
  * - `{isDirectory: true, entry}` — a `FileSystemEntry` from drag-and-drop;
- *   walked recursively via {@link flattenDirectoryEntry}.
+ *   walked locally first via {@link walkDirectoryEntry}, then realized
+ *   server-side via {@link materializeNode}. Read failures along the
+ *   walk become per-entry UNREADABLE rows instead of throwing, so a
+ *   long-path NotFoundError on Windows doesn't leave orphan folders
+ *   server-side.
  * - `{file}` whose `file.path` contains a `/` — a react-dropzone /
  *   file-selector File with a relative path; folders are created on the
  *   fly via the path-based resolver.
@@ -637,14 +747,12 @@ export const flattenEntries = async (
   const result = []
   for (const entry of entries) {
     if (entry.isDirectory && entry.entry) {
-      const subItems = await flattenDirectoryEntry(
-        entry.entry,
-        rootDirId,
+      const tree = await walkDirectoryEntry(entry.entry)
+      const subItems = await materializeNode(tree, rootDirId, '', {
         client,
         driveId,
-        '',
         nonce
-      )
+      })
       result.push(...subItems)
       continue
     }

--- a/src/modules/upload/index.spec.js
+++ b/src/modules/upload/index.spec.js
@@ -504,6 +504,19 @@ const createMockFileEntry = (name, content = '') => ({
   file: resolve => resolve(new File([content], name))
 })
 
+// A file entry whose file() rejects, simulating Windows long-path
+// NotFoundError surfacing during File extraction.
+const createUnreadableFileEntry = name => ({
+  isFile: true,
+  isDirectory: false,
+  name,
+  file: (_resolve, reject) => {
+    const err = new Error('vanished')
+    err.name = 'NotFoundError'
+    reject(err)
+  }
+})
+
 const createMockDirEntry = (name, children) => ({
   isFile: false,
   isDirectory: true,
@@ -521,6 +534,30 @@ const createMockDirEntry = (name, children) => ({
       }
     }
   }
+})
+
+// A directory entry whose readEntries rejects, simulating Windows
+// long-path NotFoundError when enumerating a deep folder.
+const createUnreadableDirEntry = name => ({
+  isFile: false,
+  isDirectory: true,
+  name,
+  createReader: () => ({
+    readEntries: (_resolve, reject) => {
+      const err = new Error('path too long')
+      err.name = 'NotFoundError'
+      reject(err)
+    }
+  })
+})
+
+const createBrokenDirEntry = name => ({
+  isFile: false,
+  isDirectory: true,
+  name,
+  createReader: () => ({
+    readEntries: (_resolve, reject) => reject(new Error('permission denied'))
+  })
 })
 
 describe('extractFilesEntries', () => {
@@ -795,6 +832,108 @@ describe('flattenEntries', () => {
     })
   })
 
+  it('still creates the ancestor folders when the deepest one is unreadable', async () => {
+    // We can't enumerate `e`, but every ancestor (and `e` itself)
+    // should still be created server-side so the user can drop the
+    // missing files into the right place by hand. A single UNREADABLE
+    // row flags the folder whose contents we couldn't read.
+    const e = createUnreadableDirEntry('e')
+    const d = createMockDirEntry('d', [e])
+    const c = createMockDirEntry('c', [d])
+    const b = createMockDirEntry('b', [c])
+    const a = createMockDirEntry('a', [b])
+    const entries = [{ file: null, isDirectory: true, entry: a }]
+
+    const result = await flattenEntries(entries, 'root', fakeClient, null)
+
+    const createdNames = createDirectorySpy.mock.calls.map(c => c[0].name)
+    expect(createdNames).toEqual(['a', 'b', 'c', 'd', 'e'])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      relativePath: 'a/b/c/d/e',
+      folderId: null,
+      status: 'unreadable',
+      isDirectory: true
+    })
+  })
+
+  it('creates empty folders even when they contain no files', async () => {
+    // Empty subfolders are part of the dropped structure; they should
+    // land in Drive verbatim so the tree matches what was dropped.
+    const empty = createMockDirEntry('empty', [])
+    const top = createMockDirEntry('top', [empty])
+    const entries = [{ file: null, isDirectory: true, entry: top }]
+
+    const result = await flattenEntries(entries, 'root', fakeClient, null)
+
+    const createdNames = createDirectorySpy.mock.calls.map(c => c[0].name)
+    expect(createdNames).toEqual(['top', 'empty'])
+    expect(result).toEqual([])
+  })
+
+  it('classifies non-NotFoundError read failures as failed, not unreadable', async () => {
+    const broken = createBrokenDirEntry('broken')
+    const top = createMockDirEntry('top', [broken])
+    const entries = [{ file: null, isDirectory: true, entry: top }]
+
+    const result = await flattenEntries(entries, 'root', fakeClient, null)
+
+    const createdNames = createDirectorySpy.mock.calls.map(c => c[0].name)
+    expect(createdNames).toEqual(['top', 'broken'])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      relativePath: 'top/broken',
+      status: 'failed'
+    })
+  })
+
+  it('uploads readable siblings and surfaces one row per unreadable subtree', async () => {
+    // top/
+    //   ok.txt              <- readable, should upload
+    //   broken/             <- readEntries fails, one unreadable row
+    //   nested/
+    //     deep.txt          <- readable, should upload
+    //     ghost.bin         <- entry.file() fails, one unreadable row
+    const broken = createUnreadableDirEntry('broken')
+    const nested = createMockDirEntry('nested', [
+      createMockFileEntry('deep.txt'),
+      createUnreadableFileEntry('ghost.bin')
+    ])
+    const top = createMockDirEntry('top', [
+      createMockFileEntry('ok.txt'),
+      broken,
+      nested
+    ])
+    const entries = [{ file: null, isDirectory: true, entry: top }]
+
+    const result = await flattenEntries(entries, 'root', fakeClient, null)
+
+    const createdNames = createDirectorySpy.mock.calls.map(c => c[0].name)
+    expect(createdNames).toEqual(['top', 'broken', 'nested'])
+
+    const readable = result.filter(r => r.status !== 'unreadable')
+    const unreadable = result.filter(r => r.status === 'unreadable')
+
+    expect(readable).toHaveLength(2)
+    expect(readable.map(r => r.relativePath).sort()).toEqual([
+      'top/nested/deep.txt',
+      'top/ok.txt'
+    ])
+
+    expect(unreadable).toHaveLength(2)
+    expect(unreadable.map(r => r.relativePath).sort()).toEqual([
+      'top/broken',
+      'top/nested/ghost.bin'
+    ])
+
+    const brokenRow = unreadable.find(r => r.relativePath === 'top/broken')
+    const ghostRow = unreadable.find(
+      r => r.relativePath === 'top/nested/ghost.bin'
+    )
+    expect(brokenRow.isDirectory).toBe(true)
+    expect(ghostRow.isDirectory).toBe(false)
+  })
+
   it('should route react-dropzone File.path entries through the folder cache', async () => {
     const nested = new File(['a'], 'a.txt')
     nested.path = '/album/2024/a.txt'
@@ -922,6 +1061,44 @@ describe('addToUploadQueue placeholder flow', () => {
     const types = actions.map(a => a.type)
     expect(types).toContain('ADD_TO_UPLOAD_QUEUE')
     expect(types).not.toContain('RESOLVE_FOLDER_ITEMS')
+  })
+
+  it('replaces the placeholder with one unreadable row when an inner folder cannot be read', async () => {
+    // Asserts the placeholder is resolved (not stuck on RESOLVING) by
+    // an UNREADABLE row — otherwise the queue would silently swallow
+    // the drop and the alert pipeline never fires.
+    const e = createUnreadableDirEntry('e')
+    const d = createMockDirEntry('d', [e])
+    const c = createMockDirEntry('c', [d])
+    const b = createMockDirEntry('b', [c])
+    const a = createMockDirEntry('a', [b])
+    const entries = [{ file: null, isDirectory: true, entry: a }]
+
+    const actions = await runThunk(
+      addToUploadQueue(
+        entries,
+        'root',
+        {},
+        () => null,
+        () => null,
+        { client: fakeClient },
+        null,
+        () => null
+      )
+    )
+
+    const createdNames = createDirectorySpy.mock.calls.map(c => c[0].name)
+    expect(createdNames).toEqual(['a', 'b', 'c', 'd', 'e'])
+    const resolves = actions.filter(a => a.type === 'RESOLVE_FOLDER_ITEMS')
+    expect(resolves).toHaveLength(1)
+    expect(resolves[0].placeholderIds).toEqual([
+      expect.stringMatching(/^__pending_.+_0_a__$/)
+    ])
+    expect(resolves[0].files).toHaveLength(1)
+    expect(resolves[0].files[0]).toMatchObject({
+      relativePath: 'a/b/c/d/e',
+      status: 'unreadable'
+    })
   })
 
   it('marks placeholders as failed if flatten throws', async () => {


### PR DESCRIPTION
## Problem

On Windows, dropping a folder where a deep path exceeds the OS length limit failed mid-walk with a `NotFoundError`. The pipeline displayed the right alert and marked the top-level placeholder as errored, but every ancestor folder up to the failure had already been created server-side. The user was left with a partial folder structure and no way to know which subtree was missing, so retrying meant guessing what was incomplete.

## Solution

- Walk the local FileSystem API tree first with no server calls; capture read failures per node instead of throwing.
- Then create the full server-side structure, including empty folders and ancestors of unreadable subtrees, so the resulting tree matches the shape that was dropped.
- Surface each failed read as its own queue row, so it's clear exactly which path was skipped.
- Tag folder failures with `isDirectory: true` so the queue renders a folder glyph for them, distinct from file failures.
- Route errors through the shared classifier: `NotFoundError` lands on `unreadable`, permission and I/O failures land on `failed`.
- Reveal the full relative path on hover via a tooltip, since long paths get ellipsised in the row.

## Changes

- Replace `flattenDirectoryEntry` with `walkDirectoryEntry` (local-only walk) and `materializeNode` (server folder creation + queue item emission); folders are always created, including empty ones.
- Add `makeFailedItem` to build queue rows for entries that couldn't be read locally, with status set via `classifyUploadError` and `isDirectory` propagated to the renderer.
- Wrap the queue row's `displayName` in a `cozy-ui` `Tooltip` (gated on `relativePath`) so deep paths are readable on hover.
- Add tests covering ancestor creation when the deepest folder is unreadable, empty-folder creation, mixed readable and unreadable siblings, the non-`NotFoundError` classification path, and the placeholder replacement flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More robust upload traversal: unreadable files/directories no longer throw during scanning, ancestor folders are still created, and unreadable items appear as distinct "unreadable" rows in the upload queue.
* **New Features**
  * Tooltips show full filenames when names are truncated in the upload queue.
* **Tests**
  * Expanded test coverage for unreadable paths, mixed readable/unreadable trees, empty directories, and placeholder resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->