### PR TITLE
fix: keep upload error alerts open until dismissed

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -42,6 +42,7 @@ declare module 'cozy-ui/transpiled/react/providers/Alert' {
       | 'info'
     action?: React.ReactNode
     duration?: number | null
+    noClickAway?: boolean
   }
 
   export type showAlertFunction = (props: showAlertProps) => void

--- a/src/modules/navigation/duck/actions.jsx
+++ b/src/modules/navigation/duck/actions.jsx
@@ -206,7 +206,8 @@ const uploadQueueProcessed =
       showAlert({
         message: t('upload.alert.network'),
         severity: 'error',
-        duration: null
+        duration: null,
+        noClickAway: true
       })
     } else if (unreadableErrors.length > 0) {
       logger.warn(
@@ -215,14 +216,16 @@ const uploadQueueProcessed =
       showAlert({
         message: t('upload.alert.unreadable_files'),
         severity: 'error',
-        duration: null
+        duration: null,
+        noClickAway: true
       })
     } else if (errors.length > 0) {
       logger.error(`Upload module triggers an error: ${errors}`)
       showAlert({
         message: t('upload.alert.errors', { type }),
         severity: 'error',
-        duration: null
+        duration: null,
+        noClickAway: true
       })
     } else if (updatedCount > 0 && createdCount > 0 && conflictCount > 0) {
       showAlert({
@@ -275,7 +278,8 @@ const uploadQueueProcessed =
           max_size_value: MAX_PAYLOAD_SIZE_IN_GB
         }),
         severity: 'error',
-        duration: null
+        duration: null,
+        noClickAway: true
       })
     } else {
       showAlert({

--- a/src/modules/views/Upload/useUploadFromFlagship.ts
+++ b/src/modules/views/Upload/useUploadFromFlagship.ts
@@ -34,7 +34,8 @@ export const useUploadFromFlagship = (): UploadFromFlagship => {
     showAlert({
       message: t('ImportToDrive.error'),
       severity: 'error',
-      duration: null
+      duration: null,
+      noClickAway: true
     })
   }, [showAlert, t])
 


### PR DESCRIPTION
## Summary

- Upload error alerts were marked persistent but still closed on any click outside the snackbar, so users often lost the message before reading it.
- Pass `noClickAway: true` on the four upload error branches and on the import-from-flagship error so the alerts only close via the X button.
- Declare the `noClickAway` prop in the local Alert provider type so consumers can opt in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to configure alerts as non-dismissible via click-away, preventing accidental dismissals during critical error scenarios.
  * Error alerts for network failures, file processing issues, and import failures now persist until action is taken.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->