### PR TITLE
fix: select-all download in public folder view

### DIFF
--- a/src/modules/views/Public/PublicFolderView.jsx
+++ b/src/modules/views/Public/PublicFolderView.jsx
@@ -183,6 +183,7 @@ const PublicFolderView = ({ sharedDocumentId }) => {
     selectAll: () => toggleSelectAllItems(filesResult.data),
     isSelectAll,
     isMobile,
+    displayedFolder,
     onClose: () => {
       refreshAfterChange()
     }


### PR DESCRIPTION
## Problem

In a publicly shared folder, selecting all items and clicking the download button in the selection bar does nothing. The toolbar's dedicated download button and the per-row download from the context menu both still work.

## Cause

The `download` action has a select-all branch that replaces the file list with `[displayedFolder]` so it can issue a single archive download for the whole folder instead of enumerating every id. That branch reads `displayedFolder` from the action options. The public folder view was building its action options without this field, so the action received `undefined` and threw on `.driveId`.

## Solution

Include `displayedFolder` in the action options the public folder view passes to `makeActions`, matching what the regular drive folder view already does.

## Demo

https://github.com/user-attachments/assets/b053c82a-dbbc-4333-9af3-b1b264e6dcbc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context awareness for folder actions in public folder views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->