### PR TITLE
fix(file-picker): UI small enhancements

### DIFF
--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -185,7 +185,7 @@ describe('FilePicker mobile navigation, list and actions', () => {
 
     expect(downloadButton).toHaveClass('u-flex-grow-1')
     expect(publicButton).toHaveClass('u-flex-grow-1')
-    expect(downloadButton).toHaveClass('MuiButton-outlined')
+    expect(downloadButton).toHaveClass('MuiButton-text')
     expect(publicButton).toHaveClass('MuiButton-contained')
     expect(downloadButton.querySelector('svg')).toBe(null)
     expect(publicButton.querySelector('svg')).toBe(null)
@@ -205,7 +205,10 @@ describe('FilePicker mobile navigation, list and actions', () => {
 
     expect(getByTestId('public-link-btn')).not.toBeDisabled()
     expect(getByTestId('temporary-download-link-btn')).toBeDisabled()
-    expect(queryByRole('button', { name: 'Clear Selection' })).toBe(null)
+    expect(
+      queryByRole('button', { name: 'Clear Selection' })
+    ).toBeInTheDocument()
+    expect(getByTestId('file-picker-selected-count')).toHaveTextContent('2')
     expect(queryByText(/item selected/)).toBe(null)
     expect(
       queryByText('FilePicker.constraints.disabledReasons.folderNotAllowed')

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -356,7 +356,7 @@ describe('FilePicker mobile navigation, list and actions', () => {
   })
 
   it('preserves desktop columns, selection and folder double-click navigation', () => {
-    const { getAllByTestId, getByTestId, queryByRole } = setup({
+    const { getAllByTestId, getByRole, getByTestId, queryByRole } = setup({
       isMobile: false
     })
     const rows = getAllByTestId('list-item')
@@ -384,6 +384,8 @@ describe('FilePicker mobile navigation, list and actions', () => {
     fireEvent.doubleClick(folderRow)
     expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
     expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('Photos')
+    fireEvent.click(getByRole('button', { name: 'Back' }))
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
     expect(queryByRole('button', { name: 'Back' })).toBe(null)
   })
 

--- a/src/modules/services/components/FilePicker/FilePickerBreadcrumb.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBreadcrumb.jsx
@@ -23,15 +23,18 @@ const FilePickerBreadcrumb = ({ path, onBreadcrumbClick }) => {
 
   return (
     <Typography
-      variant="body1"
+      variant="body2"
       data-testid="file-picker-breadcrumb"
-      className="u-flex u-flex-items-center u-fw-bold"
+      className="u-flex u-flex-items-center u-fw-bold u-h-2 u-h-2-half-s"
     >
+      {hasPath && path.length > 1 && (
+        <BackButton
+          onClick={navigateBack}
+          size={isMobile ? 'large' : 'small'}
+        />
+      )}
       {isMobile && hasPath ? (
-        <>
-          {path.length > 1 && <BackButton onClick={navigateBack} />}
-          <span>{path[path.length - 1].name}</span>
-        </>
+        <span>{path[path.length - 1].name}</span>
       ) : (
         hasPath &&
         path.map((folder, idx) => {

--- a/src/modules/services/components/FilePicker/FilePickerFooter.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerFooter.jsx
@@ -1,4 +1,10 @@
-import { Attachment, Cross, Icon, Link } from '@linagora/twake-icons'
+import {
+  Attachment,
+  CheckCircle,
+  Cross,
+  Icon,
+  Link
+} from '@linagora/twake-icons'
 import { filesize } from 'filesize'
 import PropTypes from 'prop-types'
 import React, { memo } from 'react'
@@ -34,6 +40,7 @@ const FilePickerFooter = ({
   const { isMobile } = useBreakpoints()
   const { selectedItems, clearSelection } = useSelectionContext()
   const selectedCount = selectedItems.length
+  const hasSelection = selectedCount > 0
 
   const publicLinkLabel =
     publicLinkAction &&
@@ -102,27 +109,46 @@ const FilePickerFooter = ({
           : 'u-flex u-flex-items-center u-flex-justify-between u-w-100'
       }
     >
-      {!isMobile &&
-        (selectedCount > 0 ? (
-          <Box className="u-flex u-flex-items-center">
-            <IconButton
-              onClick={clearSelection}
-              size="small"
-              aria-label={t('toolbar.clear_selection')}
-            >
-              <Icon icon={Cross} size={16} />
-            </IconButton>
+      {hasSelection ? (
+        <Box className="u-flex u-flex-items-center u-flex-shrink-0">
+          <IconButton
+            onClick={clearSelection}
+            size="small"
+            aria-label={t('toolbar.clear_selection')}
+          >
+            <Icon icon={Cross} size={16} />
+          </IconButton>
+          {isMobile ? (
+            <>
+              <Icon
+                icon={CheckCircle}
+                color="var(--primaryColor)"
+                size={16}
+                className="u-ml-half"
+              />
+              <Typography
+                variant="body1"
+                className="u-ml-half"
+                data-testid="file-picker-selected-count"
+              >
+                {selectedCount}
+              </Typography>
+            </>
+          ) : (
             <Typography variant="body1" className="u-ml-half">
               {selectedCount} {t('SelectionBar.selected_count', selectedCount)}
             </Typography>
-          </Box>
-        ) : (
-          <span />
-        ))}
+          )}
+        </Box>
+      ) : (
+        !isMobile && <span />
+      )}
       <Box
         className={
           isMobile
-            ? 'u-flex u-flex-items-center u-w-100'
+            ? `u-flex u-flex-items-center ${
+                hasSelection ? 'u-flex-grow-1' : 'u-w-100'
+              }`
             : 'u-flex u-flex-items-center'
         }
       >
@@ -133,7 +159,7 @@ const FilePickerFooter = ({
           () => onConfirm(filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK),
           'temporary-download-link-btn',
           Attachment,
-          'secondary'
+          'text'
         )}
         {renderAction(
           publicLinkLabel,

--- a/src/modules/services/components/FilePicker/FilePickerTable.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerTable.jsx
@@ -170,7 +170,14 @@ export const FilePickerTable = memo(
     )
 
     return (
-      <Box height="100%" flex={1} minHeight={0} px={3} boxSizing="border-box">
+      <Box
+        className="u-ph-1"
+        height="100%"
+        flex={1}
+        minHeight={0}
+        px={3}
+        boxSizing="border-box"
+      >
         <VirtualizedTable
           ref={virtuosoRef}
           context={tableContext}

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -202,7 +202,7 @@ const FilePicker = ({
         </Box>
         <Divider />
         <footer
-          className="u-mv-1 u-mh-2 u-flex-shrink-0-s"
+          className="u-m-1 u-flex-shrink-0-s"
           data-testid="file-picker-footer"
         >
           <FilePickerFooter


### PR DESCRIPTION

<img width="287" height="635" alt="image" src="https://github.com/user-attachments/assets/2a1f2f9e-9a50-4b67-a52e-d63520cb545a" />


- **fix(file-picker): stabilize breadcrumb navigation**
- **fix(file-picker): align mobile footer actions**
- **fix(file-picker): reduce table horizontal padding**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer mobile selection controls, including a clear-selection button and selected-item count.
  * Added a dedicated mobile Back button when browsing nested folders.
  * Improved navigation behavior when returning to the root folder.

* **Style**
  * Updated typography, spacing, responsive sizing, and action styling for a more consistent file-picker experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->