### PR TITLE
feat(file-picker): enforce maxFileCount and availableSize constraints

### DIFF
--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -102,12 +102,15 @@ interface ActionConfig {
   maxFileSize?: number
 
   /**
-   * Reserved for limiting multi-file selection. Currently not enforced.
+   * Maximum number of selectable items.
+   * Absent means no count restriction.
    */
   maxFileCount?: number
 
   /**
-   * Reserved for limiting multi-file selection. Currently not enforced.
+   * Maximum total size of selected files, in bytes.
+   * Folders do not count toward the total.
+   * Absent means no total-size restriction.
    */
   availableSize?: number
 }
@@ -196,6 +199,8 @@ When the selected item violates an action constraint, the corresponding button i
 | `allowFolder: false` and selected item is a folder | Button disabled |
 | `allowedMimeTypes` does not match selected file MIME | Button disabled |
 | selected file size > `maxFileSize` | Button disabled |
+| selected items count > `maxFileCount` | Button disabled |
+| total selected file size > `availableSize` | Button disabled |
 
 MIME matching supports:
 
@@ -205,7 +210,8 @@ image/*         any image type
 */*             any MIME type
 ```
 
-`maxFileCount` and `availableSize` are currently accepted in the config shape but are not enforced yet.
+`maxFileCount` and `availableSize` are enforced when present. Folders count
+toward `maxFileCount` but are excluded from the `availableSize` total.
 
 ## Success result
 
@@ -302,5 +308,6 @@ const handleComplete = result => {
 
 ## Limitations
 
-- `maxFileCount` is reserved but not enforced.
-- `availableSize` is reserved but not enforced.
+The count and size limits are checked on the currently selected items only: 
+`maxFileCount` counts every selected item including folders, while 
+`availableSize` sums only selected files (folders are excluded).

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -806,7 +806,9 @@
       "disabledReasons": {
         "folderNotAllowed": "Folders are not allowed for this action",
         "mimeTypeNotAllowed": "This file type is not allowed for this action",
-        "fileTooLarge": "This file is larger than %{maxFileSize}"
+        "fileTooLarge": "This file is larger than %{maxFileSize}",
+        "maxFileCountExceeded": "Too many files selected (limit %{maxFileCount})",
+        "availableSizeExceeded": "The total selected size exceeds %{availableSize}"
       }
     },
     "actions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -803,7 +803,9 @@
       "disabledReasons": {
         "folderNotAllowed": "Les dossiers ne sont pas autorisés pour cette action",
         "mimeTypeNotAllowed": "Ce type de fichier n'est pas autorisé pour cette action",
-        "fileTooLarge": "Ce fichier est plus grand que %{maxFileSize}"
+        "fileTooLarge": "Ce fichier est plus grand que %{maxFileSize}",
+        "maxFileCountExceeded": "Trop de fichiers sélectionnés (limite %{maxFileCount})",
+        "availableSizeExceeded": "La taille totale sélectionnée dépasse %{availableSize}"
       }
     },
     "actions": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -768,9 +768,11 @@
     },
     "constraints": {
       "disabledReasons": {
-        "folderNotAllowed": "Folders are not allowed for this action",
-        "mimeTypeNotAllowed": "This file type is not allowed for this action",
-        "fileTooLarge": "This file is larger than %{maxFileSize}"
+        "folderNotAllowed": "Для этого действия папки не разрешены",
+        "mimeTypeNotAllowed": "Этот тип файла не разрешён для этого действия",
+        "fileTooLarge": "Этот файл больше %{maxFileSize}",
+        "maxFileCountExceeded": "Выбрано слишком много файлов (лимит %{maxFileCount})",
+        "availableSizeExceeded": "Общий размер выбранных файлов превышает %{availableSize}"
       }
     },
     "actions": {
@@ -778,9 +780,9 @@
       "downloadLink": "Добавить как вложение"
     },
     "errors": {
-      "ITEM_NOT_FOUND": "The selected file could not be found.",
-      "SHARING_LINK_FAILED": "Could not generate a sharing link.",
-      "DOWNLOAD_LINK_FAILED": "Could not generate a download link."
+      "ITEM_NOT_FOUND": "Выбранный файл не найден.",
+      "SHARING_LINK_FAILED": "Не удалось создать ссылку для общего доступа.",
+      "DOWNLOAD_LINK_FAILED": "Не удалось создать ссылку для скачивания."
     }
   }
 }

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -770,7 +770,9 @@
       "disabledReasons": {
         "folderNotAllowed": "Thư mục không được phép cho hành động này",
         "mimeTypeNotAllowed": "Loại tệp này không được phép cho hành động này",
-        "fileTooLarge": "Tệp này lớn hơn %{maxFileSize}"
+        "fileTooLarge": "Tệp này lớn hơn %{maxFileSize}",
+        "maxFileCountExceeded": "Quá nhiều tệp được chọn (giới hạn %{maxFileCount})",
+        "availableSizeExceeded": "Tổng kích thước tệp đã chọn vượt quá %{availableSize}"
       }
     },
     "actions": {

--- a/src/modules/services/components/FilePicker/FilePickerFooter.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerFooter.jsx
@@ -22,11 +22,25 @@ import { filePickerLinkModes } from './constants'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
 
 function getTooltipTitle(t, reasonKey, actionConfig) {
-  return reasonKey === 'FilePicker.constraints.disabledReasons.fileTooLarge'
-    ? t(reasonKey, {
-        maxFileSize: filesize(actionConfig?.maxFileSize ?? 0, { base: 10 })
-      })
-    : t(reasonKey)
+  const filesizeTooltip =
+    reasonKey === 'FilePicker.constraints.disabledReasons.fileTooLarge' ||
+    reasonKey === 'FilePicker.constraints.disabledReasons.availableSizeExceeded'
+  if (filesizeTooltip) {
+    return t(reasonKey, {
+      maxFileSize: filesize(actionConfig?.maxFileSize ?? 0, { base: 10 }),
+      availableSize: filesize(actionConfig?.availableSize ?? 0, { base: 10 })
+    })
+  }
+
+  if (
+    reasonKey === 'FilePicker.constraints.disabledReasons.maxFileCountExceeded'
+  ) {
+    return t(reasonKey, {
+      maxFileCount: actionConfig?.maxFileCount
+    })
+  }
+
+  return t(reasonKey)
 }
 
 const FilePickerFooter = ({

--- a/src/modules/services/components/FilePicker/config.spec.js
+++ b/src/modules/services/components/FilePicker/config.spec.js
@@ -83,6 +83,20 @@ describe('FilePicker config', () => {
       })
     })
 
+    it('carries maxFileCount and availableSize into the action config', () => {
+      const intent = {
+        attributes: {
+          data: {
+            sharingLink: { maxFileCount: 3, availableSize: 52_428_800 }
+          }
+        }
+      }
+      const config = getFilePickerConfig(intent)
+
+      expect(config.sharingLink.maxFileCount).toBe(3)
+      expect(config.sharingLink.availableSize).toBe(52_428_800)
+    })
+
     it('preserves an explicit null action (action not offered)', () => {
       const intent = {
         attributes: { data: { downloadLink: null } }

--- a/src/modules/services/components/FilePicker/constants.js
+++ b/src/modules/services/components/FilePicker/constants.js
@@ -49,7 +49,6 @@ export const filePickerErrorCodes = {
  * shared via a public link), downloadLink does not (downloading a
  * folder is not meaningful for an attachment use case).
  */
-// TODO: enforce maxFileCount and availableSize on the downloadLink action.
 export const defaultFilePickerConfig = {
   theme: { type: 'auto' },
   multiple: true,

--- a/src/modules/services/components/FilePicker/constraints.js
+++ b/src/modules/services/components/FilePicker/constraints.js
@@ -8,8 +8,6 @@ export { matchMimeType }
 
 const { file: fileModel } = models
 
-// TODO: enforce maxFileCount and availableSize.
-
 const getFileMime = file => {
   const mime = file?.mime || mimeTypes.lookup(file?.name)
 
@@ -32,7 +30,11 @@ const getFileMime = file => {
  *    FilePicker.constraints.disabledReasons.mimeTypeNotAllowed.
  * 4. Selected item is a file larger than the action's maxFileSize ->
  *    FilePicker.constraints.disabledReasons.fileTooLarge.
- * 5. Otherwise -> enabled.
+ * 5. Selected items count exceeds the action's maxFileCount ->
+ *    FilePicker.constraints.disabledReasons.maxFileCountExceeded.
+ * 6. Total selected file size exceeds the action's availableSize ->
+ *    FilePicker.constraints.disabledReasons.availableSizeExceeded.
+ * 7. Otherwise -> enabled.
  *
  * @param {object|null|undefined} actionConfig
  * @param {object|object[]|null|undefined} selectedItems - Cozy file/folder doc(s).
@@ -70,14 +72,37 @@ export const getActionDisabledState = (actionConfig, selectedItems) => {
       }
 
       const maxFileSize = actionConfig.maxFileSize
-      if (
-        typeof maxFileSize === 'number' &&
-        Number(selectedItem.size) > maxFileSize
-      ) {
+      if (typeof maxFileSize === 'number' && selectedItem.size > maxFileSize) {
         return {
           disabled: true,
           reasonKey: 'FilePicker.constraints.disabledReasons.fileTooLarge'
         }
+      }
+    }
+  }
+
+  const maxFileCount = actionConfig.maxFileCount
+  if (typeof maxFileCount === 'number' && items.length > maxFileCount) {
+    return {
+      disabled: true,
+      reasonKey: 'FilePicker.constraints.disabledReasons.maxFileCountExceeded'
+    }
+  }
+
+  const availableSize = actionConfig.availableSize
+  if (typeof availableSize === 'number') {
+    let totalSize = 0
+    for (const selectedItem of items) {
+      if (selectedItem && fileModel.isFile(selectedItem)) {
+        totalSize += selectedItem.size
+      }
+    }
+
+    if (totalSize > availableSize) {
+      return {
+        disabled: true,
+        reasonKey:
+          'FilePicker.constraints.disabledReasons.availableSizeExceeded'
       }
     }
   }

--- a/src/modules/services/components/FilePicker/constraints.spec.jsx
+++ b/src/modules/services/components/FilePicker/constraints.spec.jsx
@@ -44,16 +44,23 @@ describe('FilePicker constraints', () => {
       type: 'file',
       name: 'a.pdf',
       mime: 'application/pdf',
-      size: '1024'
+      size: 1024
     }
     const fileBig = {
       _id: '2',
       type: 'file',
       name: 'big.pdf',
       mime: 'application/pdf',
-      size: '99999999'
+      size: 99999999
     }
-    const folder = { _id: '3', type: 'directory', name: 'docs' }
+    const filePdf2 = {
+      _id: '3',
+      type: 'file',
+      name: 'b.pdf',
+      mime: 'application/pdf',
+      size: 1024
+    }
+    const folder = { _id: '4', type: 'directory', name: 'docs' }
 
     it('should disable when action config is missing', () => {
       expect(getActionDisabledState(null, filePdf)).toEqual({
@@ -127,6 +134,70 @@ describe('FilePicker constraints', () => {
         disabled: false,
         reasonKey: null
       })
+    })
+
+    it('should disable when the selected count exceeds maxFileCount', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true, maxFileCount: 1 }, [
+          filePdf,
+          folder
+        ])
+      ).toEqual({
+        disabled: true,
+        reasonKey: 'FilePicker.constraints.disabledReasons.maxFileCountExceeded'
+      })
+    })
+
+    it('should not disable when the selected count is at or below maxFileCount', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true, maxFileCount: 2 }, [
+          filePdf,
+          folder
+        ])
+      ).toEqual({ disabled: false, reasonKey: null })
+    })
+
+    it('should not enforce maxFileCount when undefined', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true }, [filePdf, folder])
+      ).toEqual({ disabled: false, reasonKey: null })
+    })
+
+    it('should disable when the total selected file size exceeds availableSize', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true, availableSize: 2000 }, [
+          filePdf,
+          filePdf2
+        ])
+      ).toEqual({
+        disabled: true,
+        reasonKey:
+          'FilePicker.constraints.disabledReasons.availableSizeExceeded'
+      })
+    })
+
+    it('should not disable when total selected size is at or below availableSize', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true, availableSize: 2048 }, [
+          filePdf,
+          filePdf2
+        ])
+      ).toEqual({ disabled: false, reasonKey: null })
+    })
+
+    it('should not enforce availableSize when undefined', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true }, [filePdf, filePdf2])
+      ).toEqual({ disabled: false, reasonKey: null })
+    })
+
+    it('should ignore folders when computing availableSize', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true, availableSize: 1024 }, [
+          filePdf,
+          folder
+        ])
+      ).toEqual({ disabled: false, reasonKey: null })
     })
 
     it('should return enabled when no selection', () => {


### PR DESCRIPTION
getActionDisabledState only enforced per-file maxFileSize, so action buttons stayed enabled once the selection went over a client's count or total-size cap. Add two selection-level rules that disable the action and surface the matching reason key, and pipe those keys through the footer tooltip.

The ru.locale FilePicker keys that were still in English are translated as well.

fixes #4123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File selection now enforces maximum file-count and total-size limits.
  * Folders count toward item limits but not total file-size limits.
  * Clear, localized messages explain when limits are exceeded.
  * Tooltips display relevant limit values.
  * Mobile selection indicators show a check icon and item count.
* **Bug Fixes**
  * Sharing-link configuration now preserves file-count and available-size limits.
* **Documentation**
  * Updated File Picker guidance to describe enforced selection limits.
* **Tests**
  * Added coverage for boundaries, multiple selections, undefined limits, and folder handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->