### PR TITLE
fix(bundlemon): Stop tracking unstable chunk IDs

### DIFF
--- a/.bundlemonrc
+++ b/.bundlemonrc
@@ -1,18 +1,6 @@
 {
   "baseDir": "./build",
-  "pathLabels": {
-    "chunkId": "[\\d-]+"
-  },
   "files": [
-    {
-      "path": "static/js/<chunkId>.<hash>.js"
-    },
-    {
-      "path": "static/js/async/<chunkId>.<hash>.js"
-    },
-    {
-      "path": "static/js/cozy.<hash>.js"
-    },
     {
       "path": "static/js/main.<hash>.js"
     },
@@ -30,9 +18,6 @@
     },
     {
       "path": "static/js/lib-polyfill.<hash>.js"
-    },
-    {
-      "path": "static/css/cozy.<hash>.css"
     },
     {
       "path": "static/css/main.<hash>.css"
@@ -66,15 +51,15 @@
     }
   ],
   "groups": [
-      {
-          "path": "**/*.js"
-      },
-      {
-          "path": "**/*.css"
-      },
-      {
-          "path": "**/*.{png,svg,ico}"
-      }
+    {
+      "path": "**/*.js"
+    },
+    {
+      "path": "**/*.css"
+    },
+    {
+      "path": "**/*.{png,svg,ico}"
+    }
   ],
   "reportOutput": [
     "github"


### PR DESCRIPTION
Rspack's numeric chunk IDs change when the dependency graph is restructured. BundleMon normalizes all matching chunks to one path. Its comparison can therefore pair unrelated files and report misleading increases, as exposed by #4121.

Remove the per-file rules for numeric chunks and keep tracking their combined size through the existing JS and CSS groups. Drop obsolete cozy chunk rules because that cache group is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundle monitoring configuration by removing obsolete asset-specific entries.
  * Preserved existing asset matching patterns while standardizing formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->