### PR TITLE
fix(sharing): keep opening the federated modal for Drive documents

### DIFF
--- a/e2e/tests/z-file-sharing.spec.ts
+++ b/e2e/tests/z-file-sharing.spec.ts
@@ -41,18 +41,23 @@ test.describe.serial('File sharing (federated)', () => {
     } finally {
       await safeUnlink(filePath)
     }
+
+    // Confirming with no recipient picked also just closes the modal, so the
+    // owner's row on the by-me tab is what proves the share happened.
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings/by-me`)
+    await expect(aliceDrive.row(FILE_NAME).cell).toBeVisible({
+      timeout: 15_000
+    })
   })
 
   test('Bob sees the file in his Sharings tab', async ({
     bobPage,
     bobDrive
   }) => {
-    await bobPage.goto(`${USERS.bob.appUrl}/#/sharings`)
-
     // Sharing propagates asynchronously across instances; reload until the
     // federated shortcut lands in the Sharings list.
     await expect(async () => {
-      await bobPage.reload()
+      await bobPage.goto(`${USERS.bob.appUrl}/#/sharings`)
       await bobDrive.row(FILE_NAME).waitVisible({ timeout: 5_000 })
     }).toPass({ timeout: 30_000 })
   })
@@ -67,13 +72,10 @@ test.describe.serial('File sharing (federated)', () => {
 
     await row.open()
 
-    // The branch exposes a dedicated /shareddrive/:driveId/file/:fileId
-    // route for file-root shared drives, but the recipient-side row in
-    // the current state still resolves to the folder-root path
-    // (/:driveId/:folderId where :folderId is the rule's file id). The
-    // branch is mid-flight on wiring up the recipient's file-root view,
-    // so we just assert the navigation lands on the shared drive rather
-    // than locking the test to a specific route shape.
+    // A file-root shared drive still resolves to the folder-root path on the
+    // recipient's side (/:driveId/:folderId where :folderId is the rule's file
+    // id), so assert the navigation lands on the shared drive rather than
+    // locking the test to a specific route shape.
     await expect(bobPage).toHaveURL(/\/shareddrive\/[^/]+\/[^/]+/)
   })
 })

--- a/e2e/tests/z-folder-sharing.spec.ts
+++ b/e2e/tests/z-folder-sharing.spec.ts
@@ -22,18 +22,23 @@ test.describe.serial('Folder sharing', () => {
     await shareModal.waitForOpen()
     await shareModal.addMember(USERS.bob.email)
     await shareModal.share()
+
+    // Confirming with no recipient picked also just closes the modal, so the
+    // owner's row on the by-me tab is what proves the share happened.
+    await alicePage.goto(`${USERS.alice.appUrl}/#/sharings/by-me`)
+    await expect(aliceDrive.row(FOLDER_NAME).cell).toBeVisible({
+      timeout: 15_000
+    })
   })
 
   test('Bob sees the shared folder in his Sharings section', async ({
     bobPage,
     bobDrive
   }) => {
-    await bobPage.goto(`${USERS.bob.appUrl}/#/sharings`)
-
     // Sharing propagates asynchronously across instances; reload until it lands.
     await expect(async () => {
-      await bobPage.reload()
-      await bobDrive.row(FOLDER_NAME).waitVisible({ timeout: 3_000 })
+      await bobPage.goto(`${USERS.bob.appUrl}/#/sharings`)
+      await bobDrive.row(FOLDER_NAME).waitVisible({ timeout: 5_000 })
     }).toPass({ timeout: 30_000 })
   })
 })

--- a/e2e/tests/z-share-modal-surfaces.spec.ts
+++ b/e2e/tests/z-share-modal-surfaces.spec.ts
@@ -77,6 +77,15 @@ test.describe.serial('Share modal surfaces (shared drives)', () => {
     bobPage,
     bobDrive
   }) => {
+    // Expected failure: the modal mounts on the right route, then cozy-sharing
+    // takes the page down. For a recipient, FederatedFolderModal resolves
+    // `isCurrentUserOwner` from the drive sharing (false for Bob) and falls
+    // through to canReshare(fileId); a file inside a drive carries no sharing
+    // of its own, so cozy-sharing's state.js dereferences a null sharing.
+    // Kept failing rather than deleted, so the suite reports it the day the
+    // dependency stops crashing.
+    test.fail()
+
     // The v/share route lives under the recipient's proxied shared-drive
     // viewer, so this is Bob's path (he's an Editor, so the viewer's sharing
     // affordances stay enabled). The owner never reaches this route — his

--- a/e2e/tests/z-shared-drive-members.spec.ts
+++ b/e2e/tests/z-shared-drive-members.spec.ts
@@ -16,6 +16,7 @@ const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
 const VIEWER_DRIVE = `Viewer Drive ${stamp()}`
 const VIEWER_FILE = `viewer-file-${stamp()}.txt`
 const LEAVE_DRIVE = `Leave Drive ${stamp()}`
+const CRASH_DRIVE = `Crash Drive ${stamp()}`
 
 test.describe.serial('Shared drive members & permissions', () => {
   test('Alice shares a drive with Bob as Viewer', async ({
@@ -94,7 +95,9 @@ test.describe.serial('Shared drive members & permissions', () => {
     )
     const modal = await aliceDrive.row(VIEWER_DRIVE).share()
     await modal.removeMember('bob')
-    await modal.close()
+    // The modal is left open on purpose: removing the last member takes the
+    // page down with it (see the expected failure at the end of this file),
+    // and what this test is about is Bob losing access.
 
     // Revocation propagates to Bob's instance asynchronously.
     await expect(async () => {
@@ -119,5 +122,30 @@ test.describe.serial('Shared drive members & permissions', () => {
       await bobPage.goto(`${USERS.bob.appUrl}/#/sharings`)
       await bobDrive.row(LEAVE_DRIVE).waitHidden({ timeout: 5_000 })
     }).toPass({ timeout: 30_000 })
+  })
+
+  test('the share modal survives removing the last member', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    // Expected failure: revoking the last member drops the sharing from
+    // cozy-sharing's store while the modal is still mounted, and canReshare()
+    // then dereferences it (state.js reads `sharing.attributes` on a sharing
+    // that is now null), white-screening the app. Kept failing rather than
+    // deleted, so the suite reports it the day the dependency stops crashing.
+    // Last in the file: nothing else should depend on a crashed page.
+    test.fail()
+
+    await createAndShareFolderWithBob(alicePage, aliceDrive, CRASH_DRIVE)
+    await waitForSharingRow(
+      alicePage,
+      USERS.alice,
+      aliceDrive,
+      CRASH_DRIVE,
+      'by-me'
+    )
+    const modal = await aliceDrive.row(CRASH_DRIVE).share()
+    await modal.removeMember('bob')
+    await modal.close()
   })
 })

--- a/src/modules/views/Modal/ShareDisplayedFolderView.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import flag from 'cozy-flags'
-import { ShareModal } from 'cozy-sharing'
+
+import { SharingModal } from './SharingModal'
 
 import { useDisplayedFolder } from '@/hooks'
 import { getSharingsRootRoute } from '@/modules/views/Sharings/routes'
@@ -22,7 +23,7 @@ const ShareDisplayedFolderView = () => {
     }
 
     return (
-      <ShareModal
+      <SharingModal
         document={displayedFolder}
         documentType="Files"
         sharingDesc={displayedFolder.name}

--- a/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
@@ -1,9 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
-import { ShareModal } from 'cozy-sharing'
-
 import { ShareDisplayedFolderView } from './ShareDisplayedFolderView'
+import { SharingModal } from './SharingModal'
 
 import { SHARING_TAB_DRIVES, SHARING_TAB_WITH_ME } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
@@ -19,8 +18,8 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('cozy-flags', () => jest.fn())
 
-jest.mock('cozy-sharing', () => ({
-  ShareModal: jest.fn(({ onRevokeSuccess }) => (
+jest.mock('./SharingModal', () => ({
+  SharingModal: jest.fn(({ onRevokeSuccess }) => (
     <button onClick={onRevokeSuccess}>Revoke self</button>
   ))
 }))
@@ -84,7 +83,7 @@ describe('ShareDisplayedFolderView', () => {
 
     render(<ShareDisplayedFolderView />)
 
-    ShareModal.mock.calls[0][0].onClose()
+    SharingModal.mock.calls[0][0].onClose()
 
     expect(mockNavigate).toHaveBeenCalledWith('..', { replace: true })
   })

--- a/src/modules/views/Modal/ShareFileView.jsx
+++ b/src/modules/views/Modal/ShareFileView.jsx
@@ -3,7 +3,8 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
 import flag from 'cozy-flags'
-import { ShareModal } from 'cozy-sharing'
+
+import { SharingModal } from './SharingModal'
 
 import { LoaderModal } from '@/components/LoaderModal'
 import { getSharingsRootRoute } from '@/modules/views/Sharings/routes'
@@ -32,7 +33,7 @@ const ShareFileView = () => {
 
   if (hasQueryBeenLoaded(fileResult) && fileResult.data) {
     return (
-      <ShareModal
+      <SharingModal
         document={fileResult.data}
         driveId={driveId}
         documentType="Files"

--- a/src/modules/views/Modal/ShareFileView.spec.jsx
+++ b/src/modules/views/Modal/ShareFileView.spec.jsx
@@ -25,8 +25,8 @@ jest.mock('cozy-client', () => ({
 
 jest.mock('cozy-flags', () => jest.fn())
 
-jest.mock('cozy-sharing', () => ({
-  ShareModal: jest.fn(({ onRevokeSuccess }) => (
+jest.mock('./SharingModal', () => ({
+  SharingModal: jest.fn(({ onRevokeSuccess }) => (
     <button onClick={() => onRevokeSuccess({ id: 'file-id' })}>
       Revoke self
     </button>

--- a/src/modules/views/Modal/SharingModal.jsx
+++ b/src/modules/views/Modal/SharingModal.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import flag from 'cozy-flags'
+import {
+  FederatedFolderModal,
+  ShareModal,
+  useSharingContext
+} from 'cozy-sharing'
+
+/**
+ * Picks which modal a share opens.
+ *
+ * cozy-sharing routes to the federated (shared drive) flow only for documents
+ * that already carry a `driveId`, so sharing a folder from My Drive would fall
+ * back to the classic cozy-to-cozy dialog and never create a drive. Drive owns
+ * the federated feature, so it selects that modal itself. The editable check
+ * mirrors cozy-sharing's ShareModal, so a recipient who cannot reshare still
+ * gets the read-only dialog instead of the editing one.
+ */
+export const SharingModal = ({ document, ...rest }) => {
+  const { byDocId, isOwner, canReshare } = useSharingContext()
+
+  const docId = document.id ?? document._id
+  const isEditable = !byDocId[docId] || isOwner(docId) || canReshare(docId)
+
+  if (flag('drive.federated-shared-folder.enabled') && isEditable) {
+    return <FederatedFolderModal document={document} {...rest} />
+  }
+
+  return <ShareModal document={document} {...rest} />
+}
+
+SharingModal.propTypes = {
+  document: PropTypes.object.isRequired
+}

--- a/src/modules/views/Modal/SharingModal.spec.jsx
+++ b/src/modules/views/Modal/SharingModal.spec.jsx
@@ -1,0 +1,82 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import flag from 'cozy-flags'
+import {
+  FederatedFolderModal,
+  ShareModal,
+  useSharingContext
+} from 'cozy-sharing'
+
+import { SharingModal } from './SharingModal'
+
+jest.mock('cozy-flags', () => jest.fn())
+
+jest.mock('cozy-sharing', () => ({
+  FederatedFolderModal: jest.fn(() => <div>federated</div>),
+  ShareModal: jest.fn(() => <div>classic</div>),
+  useSharingContext: jest.fn()
+}))
+
+const DOCUMENT = { id: 'folder-id', name: 'Folder' }
+
+const mockSharingContext = ({
+  sharings = [],
+  owner = true,
+  reshare = false
+} = {}) => {
+  useSharingContext.mockReturnValue({
+    byDocId: sharings.length > 0 ? { [DOCUMENT.id]: { sharings } } : {},
+    isOwner: () => owner,
+    canReshare: () => reshare
+  })
+}
+
+describe('SharingModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    flag.mockImplementation(
+      name => name === 'drive.federated-shared-folder.enabled'
+    )
+  })
+
+  it('opens the federated modal for a document that is not shared yet', () => {
+    mockSharingContext()
+
+    render(<SharingModal document={DOCUMENT} />)
+
+    expect(FederatedFolderModal).toHaveBeenCalled()
+    expect(ShareModal).not.toHaveBeenCalled()
+  })
+
+  it('opens the federated modal when the user can reshare', () => {
+    mockSharingContext({
+      sharings: ['sharing-id'],
+      owner: false,
+      reshare: true
+    })
+
+    render(<SharingModal document={DOCUMENT} />)
+
+    expect(FederatedFolderModal).toHaveBeenCalled()
+  })
+
+  it('falls back to cozy-sharing when the user can neither own nor reshare', () => {
+    mockSharingContext({ sharings: ['sharing-id'], owner: false })
+
+    render(<SharingModal document={DOCUMENT} />)
+
+    expect(ShareModal).toHaveBeenCalled()
+    expect(FederatedFolderModal).not.toHaveBeenCalled()
+  })
+
+  it('falls back to cozy-sharing when the federated flag is off', () => {
+    flag.mockReturnValue(false)
+    mockSharingContext()
+
+    render(<SharingModal document={DOCUMENT} />)
+
+    expect(ShareModal).toHaveBeenCalled()
+    expect(FederatedFolderModal).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Nine sharing E2E specs were failing.

**Why**

- The cozy-sharing upgrade in 0d6184112 narrowed its federated modal to documents that already carry a `driveId`, so sharing a folder from My Drive fell back to the classic cozy-to-cozy dialog and stopped creating a shared drive.
- Nothing else in Drive creates one, and the stack only auto-accepts drive sharings, so the recipient side never received anything.
- The specs could not catch this either: confirming the modal with no recipient selected just closes it, same as a successful share.

**What changed**

- Drive picks the federated modal itself instead of relying on cozy-sharing's routing. The editable check mirrors cozy-sharing's, so a recipient who cannot reshare still gets the read-only dialog.
- Each share now asserts the owner's row on the by-me tab, so a no-op share fails the test.
- Two cozy-sharing crashes found on the way (revoking a drive's last member, a recipient opening the share modal inside a drive) are kept as `test.fail()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the appropriate sharing dialog based on document permissions and federated-sharing availability.
  * Improved sharing dialogs for files and folders.

* **Bug Fixes**
  * Improved sharing and access-revocation flows, including shared-drive scenarios.

* **Tests**
  * Expanded coverage for sharing visibility, permissions, modal behavior, and shared-drive member removal.
  * Documented known expected failures in unsupported shared-drive sharing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->