### PR TITLE
fix(file-picker): normalize file sizes for available limits

### DIFF
--- a/src/modules/navigation/components/FilePickerButton.jsx
+++ b/src/modules/navigation/components/FilePickerButton.jsx
@@ -39,6 +39,10 @@ const PICKER_CONFIGS = [
     label: 'Max size 1 KB'
   },
   {
+    id: 'max-size-and-available-size',
+    label: 'Max 50 MB per file / 100 MB total'
+  },
+  {
     id: 'no-folder-sharing',
     label: 'No folder sharing'
   }
@@ -72,6 +76,15 @@ const buildFilePickerOptions = (configId, t) => {
         downloadLink: {
           label: 'Attach small file',
           maxFileSize: 1024
+        }
+      }
+    case 'max-size-and-available-size':
+      return {
+        sharingLink: null,
+        downloadLink: {
+          label: 'Attach files',
+          maxFileSize: 50 * 1024 * 1024,
+          availableSize: 100 * 1024 * 1024
         }
       }
     case 'no-folder-sharing':

--- a/src/modules/services/components/FilePicker/constraints.js
+++ b/src/modules/services/components/FilePicker/constraints.js
@@ -28,13 +28,14 @@ const getFileMime = file => {
  * 3. Selected item is a file whose mime is not in the action's
  *    allowedMimeTypes (when that list is non-empty) ->
  *    FilePicker.constraints.disabledReasons.mimeTypeNotAllowed.
- * 4. Selected item is a file larger than the action's maxFileSize ->
+ * 4. Selected item is a file whose size is invalid -> disabled, no reason.
+ * 5. Selected item is a file larger than the action's maxFileSize ->
  *    FilePicker.constraints.disabledReasons.fileTooLarge.
- * 5. Selected items count exceeds the action's maxFileCount ->
+ * 6. Selected items count exceeds the action's maxFileCount ->
  *    FilePicker.constraints.disabledReasons.maxFileCountExceeded.
- * 6. Total selected file size exceeds the action's availableSize ->
+ * 7. Total selected file size exceeds the action's availableSize ->
  *    FilePicker.constraints.disabledReasons.availableSizeExceeded.
- * 7. Otherwise -> enabled.
+ * 8. Otherwise -> enabled.
  *
  * @param {object|null|undefined} actionConfig
  * @param {object|object[]|null|undefined} selectedItems - Cozy file/folder doc(s).
@@ -71,8 +72,21 @@ export const getActionDisabledState = (actionConfig, selectedItems) => {
         }
       }
 
+      const rawFileSize = selectedItem.size
+      const fileSize =
+        typeof rawFileSize === 'number' || typeof rawFileSize === 'string'
+          ? Number(rawFileSize)
+          : NaN
+      if (
+        (typeof rawFileSize === 'string' && rawFileSize.trim() === '') ||
+        !Number.isFinite(fileSize) ||
+        fileSize < 0
+      ) {
+        return { disabled: true, reasonKey: null }
+      }
+
       const maxFileSize = actionConfig.maxFileSize
-      if (typeof maxFileSize === 'number' && selectedItem.size > maxFileSize) {
+      if (typeof maxFileSize === 'number' && fileSize > maxFileSize) {
         return {
           disabled: true,
           reasonKey: 'FilePicker.constraints.disabledReasons.fileTooLarge'
@@ -94,7 +108,7 @@ export const getActionDisabledState = (actionConfig, selectedItems) => {
     let totalSize = 0
     for (const selectedItem of items) {
       if (selectedItem && fileModel.isFile(selectedItem)) {
-        totalSize += selectedItem.size
+        totalSize += Number(selectedItem.size)
       }
     }
 

--- a/src/modules/services/components/FilePicker/constraints.spec.jsx
+++ b/src/modules/services/components/FilePicker/constraints.spec.jsx
@@ -129,6 +129,32 @@ describe('FilePicker constraints', () => {
       })
     })
 
+    it('should reject files with invalid sizes', () => {
+      const invalidSizes = [
+        undefined,
+        null,
+        '',
+        'not-a-number',
+        NaN,
+        Infinity,
+        -1
+      ]
+
+      for (const size of invalidSizes) {
+        expect(
+          getActionDisabledState(
+            { allowFolder: true, maxFileSize: 2048 },
+            { ...filePdf, size }
+          )
+        ).toEqual({ disabled: true, reasonKey: null })
+        expect(
+          getActionDisabledState({ allowFolder: true, availableSize: 2048 }, [
+            { ...filePdf, size }
+          ])
+        ).toEqual({ disabled: true, reasonKey: null })
+      }
+    })
+
     it('should not enforce maxFileSize when undefined', () => {
       expect(getActionDisabledState({ allowFolder: true }, fileBig)).toEqual({
         disabled: false,
@@ -181,6 +207,15 @@ describe('FilePicker constraints', () => {
         getActionDisabledState({ allowFolder: true, availableSize: 2048 }, [
           filePdf,
           filePdf2
+        ])
+      ).toEqual({ disabled: false, reasonKey: null })
+    })
+
+    it('should sum string file sizes numerically', () => {
+      expect(
+        getActionDisabledState({ allowFolder: true, availableSize: 2048 }, [
+          { ...filePdf, size: '1024' },
+          { ...filePdf2, size: '1024' }
         ])
       ).toEqual({ disabled: false, reasonKey: null })
     })

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -33,13 +33,15 @@ jest.mock('./FilePickerBody', () => {
   const file = {
     _id: 'file-id',
     type: 'file',
-    name: 'file.pdf'
+    name: 'file.pdf',
+    size: 1024
   }
 
   const secondFile = {
     _id: 'second-file-id',
     type: 'file',
-    name: 'second-file.pdf'
+    name: 'second-file.pdf',
+    size: 2048
   }
 
   const folder = {
@@ -264,7 +266,8 @@ describe('FilePicker', () => {
           {
             _id: 'file-id',
             type: 'file',
-            name: 'file.pdf'
+            name: 'file.pdf',
+            size: 1024
           }
         ],
         filePickerLinkModes.PUBLIC_LINK,
@@ -313,11 +316,12 @@ describe('FilePicker', () => {
     await waitFor(() =>
       expect(mockOnChange).toHaveBeenCalledWith(
         [
-          { _id: 'file-id', type: 'file', name: 'file.pdf' },
+          { _id: 'file-id', type: 'file', name: 'file.pdf', size: 1024 },
           {
             _id: 'second-file-id',
             type: 'file',
-            name: 'second-file.pdf'
+            name: 'second-file.pdf',
+            size: 2048
           }
         ],
         filePickerLinkModes.PUBLIC_LINK,
@@ -369,7 +373,8 @@ describe('FilePicker', () => {
           {
             _id: 'file-id',
             type: 'file',
-            name: 'file.pdf'
+            name: 'file.pdf',
+            size: 1024
           },
           filePickerLinkModes.PUBLIC_LINK
         )
@@ -418,7 +423,7 @@ describe('FilePicker', () => {
 
       await waitFor(() =>
         expect(mockOnFileDoubleClick).toHaveBeenCalledWith(
-          { _id: 'file-id', type: 'file', name: 'file.pdf' },
+          { _id: 'file-id', type: 'file', name: 'file.pdf', size: 1024 },
           filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK
         )
       )


### PR DESCRIPTION
Cozy file documents can expose size as a string. Normalize sizes before summing selected files so availableSize checks do not concatenate values and disable valid selections. Add a demo configuration to reproduce the multi-file case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file attachments with a 50 MB per-file limit and 100 MB total limit.
  * Added an “Attach files” action; sharing links are unavailable.

* **Bug Fixes**
  * Improved file-size validation for numeric and text-based values.
  * Invalid, blank, negative, or non-numeric sizes are now rejected.
  * Ensured text-based file sizes are correctly included in total-size calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->