### PR TITLE
feat(file-picker): Show busy state during confirmation

### DIFF
--- a/src/modules/services/components/FilePicker/FilePickerFooter.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerFooter.jsx
@@ -48,7 +48,8 @@ const FilePickerFooter = ({
   publicLinkState,
   downloadLinkState,
   publicLinkAction,
-  downloadLinkAction
+  downloadLinkAction,
+  busyLinkMode
 }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -65,10 +66,10 @@ const FilePickerFooter = ({
       t('FilePicker.footer.buttons.temporaryDownloadLink'))
 
   const renderAction = (
+    linkMode,
     label,
     state,
     actionConfig,
-    onClick,
     testId,
     IconComponent,
     mobileVariant,
@@ -93,8 +94,9 @@ const FilePickerFooter = ({
           )
         }
         variant={isMobile ? mobileVariant : 'primary'}
-        onClick={onClick}
+        onClick={() => onConfirm(linkMode)}
         disabled={state.disabled}
+        busy={busyLinkMode === linkMode}
       />
     )
 
@@ -167,19 +169,19 @@ const FilePickerFooter = ({
         }
       >
         {renderAction(
+          filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK,
           downloadLinkLabel,
           downloadLinkState,
           downloadLinkAction,
-          () => onConfirm(filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK),
           'temporary-download-link-btn',
           Attachment,
           'text'
         )}
         {renderAction(
+          filePickerLinkModes.PUBLIC_LINK,
           publicLinkLabel,
           publicLinkState,
           publicLinkAction,
-          () => onConfirm(filePickerLinkModes.PUBLIC_LINK),
           'public-link-btn',
           Link,
           'primary',
@@ -201,14 +203,16 @@ FilePickerFooter.propTypes = {
     reasonKey: PropTypes.string
   }),
   publicLinkAction: PropTypes.object,
-  downloadLinkAction: PropTypes.object
+  downloadLinkAction: PropTypes.object,
+  busyLinkMode: PropTypes.string
 }
 
 FilePickerFooter.defaultProps = {
   publicLinkState: { disabled: true, reasonKey: null },
   downloadLinkState: { disabled: true, reasonKey: null },
   publicLinkAction: null,
-  downloadLinkAction: null
+  downloadLinkAction: null,
+  busyLinkMode: null
 }
 
 export default memo(FilePickerFooter)

--- a/src/modules/services/components/FilePicker/FilePickerFooter.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerFooter.spec.jsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { createMockClient } from 'cozy-client'
+
+import FilePickerFooter from './FilePickerFooter'
+import { filePickerLinkModes } from './constants'
+import AppLike from 'test/components/AppLike'
+
+it('shows the attachment action as busy while confirming', () => {
+  const client = createMockClient({})
+
+  const { getByTestId } = render(
+    <AppLike client={client}>
+      <FilePickerFooter
+        onConfirm={jest.fn()}
+        downloadLinkState={{ disabled: false, reasonKey: null }}
+        downloadLinkAction={{ label: 'Add as attachment' }}
+        busyLinkMode={filePickerLinkModes.TEMPORARY_DOWNLOAD_LINK}
+      />
+    </AppLike>
+  )
+
+  const button = getByTestId('temporary-download-link-btn')
+  expect(button).toBeDisabled()
+  expect(button.querySelector('.twake-icon--spin')).toBeInTheDocument()
+})

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -50,6 +50,7 @@ const FilePicker = ({
     useSelectionContext()
   const { showAlert } = useAlert()
   const isProcessingRef = useRef(false)
+  const [busyLinkMode, setBusyLinkMode] = useState(null)
   const itemsIdsSelected = useMemo(
     () => selectedItems.map(item => item._id),
     [selectedItems]
@@ -66,16 +67,25 @@ const FilePicker = ({
   }
 
   const handleConfirm = async linkMode => {
-    setError(null)
-    const value = multiple ? itemsIdsSelected : itemsIdsSelected[0]
-    const pickError = await onChange(value, linkMode)
-    if (pickError) {
-      setError(pickError)
-      return pickError
-    }
+    if (busyLinkMode) return null
 
-    clearSelection()
-    return null
+    setBusyLinkMode(linkMode)
+    setError(null)
+
+    const value = multiple ? itemsIdsSelected : itemsIdsSelected[0]
+
+    try {
+      const pickError = await onChange(value, linkMode)
+      if (pickError) {
+        setError(pickError)
+        return pickError
+      }
+
+      clearSelection()
+      return null
+    } finally {
+      setBusyLinkMode(null)
+    }
   }
 
   const handleOpenLinkAccess = useCallback(() => {
@@ -211,6 +221,7 @@ const FilePicker = ({
             downloadLinkState={downloadLinkState}
             publicLinkAction={publicLinkAction}
             downloadLinkAction={downloadLinkAction}
+            busyLinkMode={busyLinkMode}
           />
         </footer>
       </Paper>


### PR DESCRIPTION
Display the loading state on the selected link action while onChange is processing so users receive feedback and cannot submit the same action repeatedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file link actions by showing which action is in progress.
  - Prevented duplicate confirmations while a file link request is processing.
  - Ensured action buttons return to their normal state after success or failure.

- **Tests**
  - Added coverage verifying that the temporary download action is busy and disabled during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->