### PR TITLE
feat: Implement a close button inside File Picker

### DIFF
--- a/src/modules/navigation/components/FilePickerButton.jsx
+++ b/src/modules/navigation/components/FilePickerButton.jsx
@@ -176,6 +176,7 @@ export const FilePickerButton = () => {
         fullWidth
         maxWidth="md"
         iframeProps={{ spinnerProps: { middle: true } }}
+        showCloseButton={false}
         onComplete={handleComplete}
         onDismiss={handleDismiss}
       >

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -122,6 +122,7 @@ jest.mock('cozy-ui/transpiled/react/Table/Virtualized', () => {
 
 const mockOnChange = jest.fn()
 const mockOnFileDoubleClick = jest.fn()
+const mockOnClose = jest.fn()
 
 function getVisibleText(element) {
   return element.textContent.replaceAll('\u200e', '')
@@ -143,6 +144,7 @@ function setup({
         multiple={multiple}
         onChange={mockOnChange}
         onFileDoubleClick={mockOnFileDoubleClick}
+        onClose={mockOnClose}
       />
     </AppLike>
   )

--- a/src/modules/services/components/FilePicker/FilePickerHeader.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerHeader.jsx
@@ -1,14 +1,29 @@
+import { Cross, Icon } from '@linagora/twake-icons'
 import React from 'react'
 
 import AppTitle from 'cozy-ui/transpiled/react/AppTitle'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import { useI18n } from 'twake-i18n'
 
 import Drive from '@/components/Icons/Drive'
 import DriveText from '@/components/Icons/DriveText'
 
-const FilePickerHeader = () => (
-  <div className="u-flex u-flex-items-center" data-testid="file-picker-header">
-    <AppTitle appIcon={Drive} appTextIcon={DriveText} />
-  </div>
-)
+const FilePickerHeader = ({ onClose }) => {
+  const { t } = useI18n()
+
+  return (
+    <div
+      className="u-flex u-flex-justify-between u-flex-items-center"
+      data-testid="file-picker-header"
+    >
+      <AppTitle appIcon={Drive} appTextIcon={DriveText} />
+      {onClose && (
+        <IconButton onClick={onClose} aria-label={t('FilePicker.close')}>
+          <Icon icon={Cross} />
+        </IconButton>
+      )}
+    </div>
+  )
+}
 
 export default FilePickerHeader

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -37,6 +37,7 @@ export const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 
 const FilePicker = ({
   onChange,
+  onClose,
   accept,
   multiple,
   filePickerConfig,
@@ -177,10 +178,10 @@ const FilePicker = ({
         data-testid="file-picker"
       >
         <header
-          className="u-pv-1-half u-pl-1-half u-pr-2"
+          className="u-pv-1 u-pl-2 u-pr-1"
           data-testid="file-picker-header-wrapper"
         >
-          <FilePickerHeader />
+          <FilePickerHeader onClose={onClose} />
         </header>
         <Divider />
         <Box
@@ -230,6 +231,7 @@ const FilePicker = ({
 
 FilePicker.propTypes = {
   onChange: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   accept: PropTypes.string,
   multiple: PropTypes.bool,
   filePickerConfig: PropTypes.shape({

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -182,11 +182,13 @@ const FilePickerWrapper = ({ children }) => (
 describe('FilePicker', () => {
   const mockOnChange = jest.fn()
   const mockOnFileDoubleClick = jest.fn()
+  const mockOnClose = jest.fn()
 
   const setup = ({
     filePickerConfig,
     multiple = false,
     onFileDoubleClick,
+    onClose,
     accept
   } = {}) => {
     return render(
@@ -194,6 +196,7 @@ describe('FilePicker', () => {
         <FilePicker
           onChange={mockOnChange}
           onFileDoubleClick={onFileDoubleClick ?? mockOnFileDoubleClick}
+          onClose={onClose ?? mockOnClose}
           filePickerConfig={filePickerConfig}
           multiple={multiple}
           accept={accept}

--- a/src/modules/services/components/Picker.jsx
+++ b/src/modules/services/components/Picker.jsx
@@ -139,10 +139,15 @@ const Picker = ({ service, intent, onReadyToUse }) => {
     }
   }
 
+  const handleClose = () => {
+    service.cancel()
+  }
+
   return (
     <FilePicker
       onChange={handlePick}
       onFileDoubleClick={handleFileDoubleClick}
+      onClose={handleClose}
       filePickerConfig={filePickerConfig}
       onReadyToUse={onReadyToUse}
       multiple={filePickerConfig.multiple}


### PR DESCRIPTION
So the close button is standardized and centralized in the File Picker. It calls service.cancel() which send a cancel event to the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a close button to the file picker header.
  - Closing the file picker now cancels the active picker operation and dismisses the interface.
- **UI Improvements**
  - Updated the file picker header layout to position the title and close control clearly.
  - Removed the redundant close button from the surrounding dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->