### PR TITLE
fix(file-picker): UI improvements

### DIFF
--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -122,6 +122,7 @@ export const makeMobileHandlers = ({
   // used to determine if it's a longpress
   // i.e. delay onClick
   const startPressTimer = e => {
+    if (disabled || isRenaming) return
     e.persist()
     isLongPress.current = false
     timerId.current = setTimeout(() => {

--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -93,7 +93,12 @@ export const handlePress = ({
 
   // isLongPress is to prevent executing onPress twice while a longpress
   // can happen if button is released quickly just after startPressTimer execution
-  if (disabled || isLongPress.current || isRenaming) return
+  if (disabled || isRenaming) return
+
+  if (isLongPress.current) {
+    isLongPress.current = false
+    return
+  }
 
   if (selectionModeActive) {
     toggle(event)
@@ -132,6 +137,14 @@ export const makeMobileHandlers = ({
     isLongPress.current = false
   }
 
+  const startMousePress = event => {
+    // Touch devices can synthesize mouse events after touchend. Do not restart
+    // the timer after a long touch, otherwise its click would toggle twice.
+    if (!isLongPress.current) startPressTimer(event)
+  }
+
+  const cancelMousePress = () => clearTimeout(timerId.current)
+
   return {
     // first event triggered on Mobile when taping an item
     onTouchStart: startPressTimer,
@@ -140,6 +153,11 @@ export const makeMobileHandlers = ({
     onTouchCancel: cancelPress,
     // third event triggered on Mobile when taping an item
     onTouchEnd: () => clearTimeout(timerId.current),
+    // A resized desktop window still produces mouse events.
+    onMouseDown: startMousePress,
+    onMouseMove: cancelMousePress,
+    onMouseUp: cancelMousePress,
+    onMouseLeave: cancelMousePress,
     // fourth event triggered on Mobile
     onClick: event =>
       handlePress({

--- a/src/hooks/useOnLongPress/helpers.js
+++ b/src/hooks/useOnLongPress/helpers.js
@@ -140,7 +140,8 @@ export const makeMobileHandlers = ({
   const startMousePress = event => {
     // Touch devices can synthesize mouse events after touchend. Do not restart
     // the timer after a long touch, otherwise its click would toggle twice.
-    if (!isLongPress.current) startPressTimer(event)
+    if (disabled || isLongPress.current) return
+    startPressTimer(event)
   }
 
   const cancelMousePress = () => clearTimeout(timerId.current)

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -247,6 +247,27 @@ describe('FilePicker mobile navigation, list and actions', () => {
     expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
   })
 
+  it('supports a mouse long press when the layout is mobile', () => {
+    jest.useFakeTimers()
+    const { getAllByTestId, getByTestId } = setup({ isMobile: false })
+    act(() => {
+      window.innerWidth = 500
+      fireEvent.resize(window)
+      jest.advanceTimersByTime(100)
+    })
+    const folderRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFolder.id
+    )
+
+    fireEvent.mouseDown(folderRow)
+    act(() => jest.advanceTimersByTime(250))
+    fireEvent.mouseUp(folderRow)
+    fireEvent.click(folderRow)
+
+    expect(within(folderRow).getByRole('checkbox')).toBeChecked()
+    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
+  })
+
   it('cancels pending selection when touch movement starts', () => {
     jest.useFakeTimers()
     const { getAllByTestId, getByTestId, queryAllByRole } = setup()

--- a/src/modules/services/components/FilePicker/FilePickerBreadcrumb.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBreadcrumb.jsx
@@ -28,10 +28,7 @@ const FilePickerBreadcrumb = ({ path, onBreadcrumbClick }) => {
       className="u-flex u-flex-items-center u-fw-bold u-h-2 u-h-2-half-s"
     >
       {hasPath && path.length > 1 && (
-        <BackButton
-          onClick={navigateBack}
-          size={isMobile ? 'large' : 'small'}
-        />
+        <BackButton onClick={navigateBack} size="small" />
       )}
       {isMobile && hasPath ? (
         <span>{path[path.length - 1].name}</span>

--- a/src/modules/services/components/FilePicker/FilePickerFooter.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerFooter.jsx
@@ -144,7 +144,7 @@ const FilePickerFooter = ({
               />
               <Typography
                 variant="body1"
-                className="u-ml-half"
+                className="u-ml-half u-mr-1"
                 data-testid="file-picker-selected-count"
               >
                 {selectedCount}

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -95,21 +95,30 @@ const FilePicker = ({
   }, [])
 
   const handleLinkAccessConfirm = async sharingLinks => {
-    const pickError = await onChange(
-      selectedItems,
-      filePickerLinkModes.PUBLIC_LINK,
-      sharingLinks
-    )
-    if (pickError) {
-      showAlert({ message: pickError, severity: 'error' })
-      return
-    }
+    if (busyLinkMode) return
 
-    clearSelection()
-    setIsLinkAccessOpen(false)
+    setBusyLinkMode(filePickerLinkModes.PUBLIC_LINK)
+    try {
+      const pickError = await onChange(
+        selectedItems,
+        filePickerLinkModes.PUBLIC_LINK,
+        sharingLinks
+      )
+      if (pickError) {
+        showAlert({ message: pickError, severity: 'error' })
+        return
+      }
+
+      clearSelection()
+      setIsLinkAccessOpen(false)
+    } finally {
+      setBusyLinkMode(null)
+    }
   }
 
   const handleFooterConfirm = linkMode => {
+    if (busyLinkMode) return
+
     if (linkMode === filePickerLinkModes.PUBLIC_LINK) {
       handleOpenLinkAccess()
       return

--- a/src/modules/services/components/FilePicker/index.jsx
+++ b/src/modules/services/components/FilePicker/index.jsx
@@ -187,10 +187,7 @@ const FilePicker = ({
         square
         data-testid="file-picker"
       >
-        <header
-          className="u-pv-1 u-pl-2 u-pr-1"
-          data-testid="file-picker-header-wrapper"
-        >
+        <header className="u-p-1" data-testid="file-picker-header-wrapper">
           <FilePickerHeader onClose={onClose} />
         </header>
         <Divider />

--- a/src/modules/services/components/FilePicker/index.spec.jsx
+++ b/src/modules/services/components/FilePicker/index.spec.jsx
@@ -279,6 +279,28 @@ describe('FilePicker', () => {
     )
   })
 
+  it('should ignore a second public-link confirmation while the first is in-flight', async () => {
+    let resolveFirst
+    mockOnChange.mockReturnValue(
+      new Promise(resolve => {
+        resolveFirst = resolve
+      })
+    )
+    const { getByTestId, findByTestId } = setup()
+
+    fireEvent.click(getByTestId('select-file-btn'))
+    fireEvent.click(getByTestId('public-link-btn'))
+
+    await findByTestId('link-access-modal')
+    fireEvent.click(getByTestId('confirm-link-access-btn'))
+    fireEvent.click(getByTestId('confirm-link-access-btn'))
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1)
+
+    resolveFirst(null)
+    await waitFor(() => expect(mockShowAlert).not.toHaveBeenCalled())
+  })
+
   it('should keep link access open when link generation fails', async () => {
     mockOnChange.mockResolvedValueOnce('SHARING_LINK_FAILED')
     const { getByTestId, findByTestId } = setup()


### PR DESCRIPTION
 What

 Improve File Picker navigation, spacing, and mobile long-press selection behavior.

 Why

 Ensure folders can be selected with a long press when the browser window is resized to a mobile layout, while keeping touch interactions unchanged.

 How

 - Stabilize breadcrumb height and desktop back navigation.
 - Align the picker header and mobile selection counter spacing.
 - Handle mouse press events alongside touch events.
 - Prevent duplicate actions from synthesized clicks after touch long presses.

 Testing

 - Targeted File Picker mobile tests: 16 passed.
 - ESLint passed for the modified files.

 Checklist

 - [x] Tests added/updated
 - [ ] Documentation updated
 - [x] No breaking changes (or documented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved long-press folder selection on mobile and after window resizing.
  - Prevented duplicate selection toggles from touch and mouse events.
  - Reset long-press state correctly when selection is disabled or renaming is active.
  - Prevented repeated public-link confirmations while an operation is in progress.
  - Standardized the breadcrumb back-button size on mobile.

- **Style**
  - Adjusted file picker header spacing.
  - Improved spacing around the selected-item count in the mobile footer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->