### PR TITLE
fix(file-picker): select files on mobile tap

### DIFF
--- a/e2e/tests/file-picker.mobile.spec.ts
+++ b/e2e/tests/file-picker.mobile.spec.ts
@@ -63,6 +63,12 @@ test.describe('File Picker mobile', () => {
 
     await picker.navigateToFolderOnMobile(parentFolder)
     await picker.tapItem(fileName)
+    await expect.poll(() => picker.getCheckboxCount()).toBe(2)
+    await expect(picker.isItemChecked(fileName)).resolves.toBe(true)
+    await expect(picker.isTemporaryDownloadDisabled()).resolves.toBe(false)
+    await expect(picker.isPublicLinkDisabled()).resolves.toBe(false)
+
+    await picker.tapItem(fileName)
     await expect.poll(() => picker.getCheckboxCount()).toBe(0)
     await expect(picker.isTemporaryDownloadDisabled()).resolves.toBe(true)
     await expect(picker.isPublicLinkDisabled()).resolves.toBe(true)

--- a/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
+++ b/src/modules/services/components/FilePicker/FilePicker.mobile.spec.jsx
@@ -394,22 +394,17 @@ describe('FilePicker mobile navigation, list and actions', () => {
     expect(queryByRole('button', { name: 'Back' })).toBe(null)
   })
 
-  it('leaves files unselected and gives double taps no extra behavior', () => {
+  it('selects files on a single tap', () => {
     const { getAllByTestId, getByTestId } = setup()
-    const rows = getAllByTestId('list-item')
-    const folderRow = rows.find(row => row.dataset.fileId === mockFolder.id)
-    const fileRow = rows.find(row => row.dataset.fileId === mockFile.id)
+    const fileRow = getAllByTestId('list-item').find(
+      row => row.dataset.fileId === mockFile.id
+    )
 
-    fireEvent.click(fileRow)
-    fireEvent.click(fileRow)
-    fireEvent.doubleClick(fileRow)
+    tap(fileRow)
 
-    expect(getByTestId('public-link-btn')).toBeDisabled()
+    expect(within(fileRow).getByRole('checkbox')).toBeChecked()
+    expect(getByTestId('public-link-btn')).not.toBeDisabled()
     expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('My Drive')
-
-    fireEvent.click(folderRow)
-
-    expect(getByTestId('file-picker-breadcrumb')).toHaveTextContent('Photos')
     expect(mockOnFileDoubleClick).not.toHaveBeenCalled()
     expect(mockOnChange).not.toHaveBeenCalled()
   })

--- a/src/modules/services/components/FilePicker/FilePickerBody.jsx
+++ b/src/modules/services/components/FilePicker/FilePickerBody.jsx
@@ -96,10 +96,14 @@ const FilePickerBody = ({
   )
 
   const handleMobileItemClick = useCallback(
-    item => {
-      if (isDirectory(item)) navigateTo(item)
+    (item, event) => {
+      if (isDirectory(item)) {
+        navigateTo(item)
+      } else {
+        handleMobileToggleSelect(item, event)
+      }
     },
-    [navigateTo]
+    [handleMobileToggleSelect, navigateTo]
   )
 
   return (


### PR DESCRIPTION
Mobile single taps on files previously left the picker without a selection, making the available actions appear unresponsive. Reuse the long-press selection behavior and cover it in unit and end-to-end tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile file picker behavior so tapping a folder opens it and tapping a file selects or deselects it.
  * File selection now correctly enables temporary download and public-link actions.
  * Updated mobile behavior to keep users in the current folder when selecting files.
  * Refined selection state feedback when files are selected or deselected.
  * Improved mobile checks to confirm selected files display the correct checked state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->