### PR TITLE
fix(e2e): wait for sharing folder readiness

### DIFF
--- a/e2e/helpers/sharing.ts
+++ b/e2e/helpers/sharing.ts
@@ -32,10 +32,12 @@ export async function createAndShareFolderWithBob(
   await aliceDrive.createFolder(folderName)
   await aliceDrive.row(folderName).open()
   await alicePage.waitForURL(/\/folder\/[^/]+$/)
+  const shareButton = alicePage.getByRole('button', { name: /share/i })
+  await shareButton.waitFor({ state: 'visible' })
 
   await opts.seed?.()
 
-  await alicePage.getByRole('button', { name: /share/i }).click()
+  await shareButton.click()
   const modal = new ShareModalPage(alicePage)
   await modal.waitForOpen()
   if (opts.role) await modal.setNewMemberRole(opts.role)

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "cozy-pouch-link": "^60.29.0",
     "cozy-realtime": "^5.9.3",
     "cozy-search": "^2.0.2",
-    "cozy-sharing": "^37.2.12",
+    "cozy-sharing": "^37.5.2",
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^141.0.0",
     "cozy-ui-plus": "^12.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11710,7 +11710,7 @@ __metadata:
     cozy-pouch-link: "npm:^60.29.0"
     cozy-realtime: "npm:^5.9.3"
     cozy-search: "npm:^2.0.2"
-    cozy-sharing: "npm:^37.2.12"
+    cozy-sharing: "npm:^37.5.2"
     cozy-stack-client: "npm:^60.28.0"
     cozy-tsconfig: "npm:^1.8.1"
     cozy-ui: "npm:^141.0.0"
@@ -12059,9 +12059,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-sharing@npm:^37.2.12":
-  version: 37.2.12
-  resolution: "cozy-sharing@npm:37.2.12"
+"cozy-sharing@npm:^37.5.2":
+  version: 37.5.2
+  resolution: "cozy-sharing@npm:37.5.2"
   dependencies:
     "@cozy/minilog": "npm:^1.0.0"
     classnames: "npm:^2.5.1"
@@ -12084,7 +12084,7 @@ __metadata:
     react: ">=16.12.0"
     react-router: ">=5.0.1"
     twake-i18n: ">=0.3.0"
-  checksum: 10/eb0c6ecb3aebd2751c41bbd78b1b7ca4fbd57d6ea6febf0d41c27183500925c24aa8405c97437c2675d4c893ae21ac436a747eeeed6d4342e12e097bde0c23f7
+  checksum: 10/311cfb7c744417a13ac69604ec665bcc04511bbf3ef83d508f8ce32b1b4ecd9745cdf0b06a001340f8b50a971e3fd36b747b6359e6689e51e99a31bea800950e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrade cozy-sharing to 37.5.2.
- Wait for the folder sharing action before seeding shared-drive scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of folder sharing by ensuring the Share action is ready before use.
  - Updated the sharing experience to the latest version, bringing compatibility and stability improvements.
  - Strengthened sharing workflows involving folders with existing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->