### PR TITLE
Fix File Picker theme when theme forced on instance settings

### DIFF
--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -48,9 +48,9 @@ It is not a top-level `actions` field.
 interface FilePickerConfig {
   /**
    * Theme used to render the File Picker.
-   * Defaults to { type: "auto" }.
+   * Defaults to { type: undefined }.
    */
-  theme?: { type: 'light' | 'dark' | 'auto' }
+  theme?: { type: 'light' | 'dark' | undefined }
 
   /**
    * Whether several files or folders can be selected.
@@ -122,7 +122,7 @@ When no config is provided, Drive uses:
 
 ```js
 {
-  theme: { type: 'auto' },
+  theme: { type: undefined },
   multiple: true,
   sharingLink: { allowFolder: true },
   downloadLink: { allowFolder: false }
@@ -135,9 +135,9 @@ Use `theme.type` with `light` or `dark` to force the File Picker theme. The
 theme is fixed when the intent is created and does not change while it remains
 open.
 
-`auto`, an invalid value or an omitted value preserves the existing behavior:
+`undefined`, an invalid value or an omitted value preserves the existing behavior:
 the iframe follows the Cozy instance theme, with the system color scheme as a
-fallback. For `auto`, omit `theme` from the options passed to
+fallback. For `undefined`, omit `theme` from the options passed to
 `IntentDialogOpener`, which only accepts explicit `light` or `dark` values.
 `IntentDialogOpener` and `IntentIframe` from `cozy-ui-plus >= 12.2.0` apply an
 explicit theme to their dialog, close button and loading surface.
@@ -308,6 +308,6 @@ const handleComplete = result => {
 
 ## Limitations
 
-The count and size limits are checked on the currently selected items only: 
-`maxFileCount` counts every selected item including folders, while 
+The count and size limits are checked on the currently selected items only:
+`maxFileCount` counts every selected item including folders, while
 `availableSize` sums only selected files (folders are excluded).

--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -129,6 +129,13 @@ When no config is provided, Drive uses:
 }
 ```
 
+Default labels:
+
+| Action | Default label |
+| --- | --- |
+| `sharingLink` | `Share with public link` |
+| `downloadLink` | `Attach with temporary link` |
+
 ### Theme
 
 Use `theme.type` with `light` or `dark` to force the File Picker theme. The
@@ -148,13 +155,6 @@ Custom intent containers remain responsible for styling their own UI. For raw
 intents, pass the `theme` object in `attributes.data` like the other File Picker
 options. The option never changes Cozy settings, local storage or the caller's
 global theme.
-
-Default labels:
-
-| Action | Default label |
-| --- | --- |
-| `sharingLink` | `Share with public link` |
-| `downloadLink` | `Attach with temporary link` |
 
 ## Actions
 

--- a/docs/file-picker-intent.md
+++ b/docs/file-picker-intent.md
@@ -144,7 +144,11 @@ open.
 
 `undefined`, an invalid value or an omitted value preserves the existing behavior:
 the iframe follows the Cozy instance theme, with the system color scheme as a
-fallback. For `undefined`, omit `theme` from the options passed to
+fallback. But following the Cozy instance theme imply to send a request to the backend
+and the theme may change after the request succeed. So if the client app knows its theme,
+it should pass it to ensure no theme glitch.
+
+For `undefined`, omit `theme` from the options passed to
 `IntentDialogOpener`, which only accepts explicit `light` or `dark` values.
 `IntentDialogOpener` and `IntentIframe` from `cozy-ui-plus >= 12.2.0` apply an
 explicit theme to their dialog, close button and loading surface.

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "cozy-sharing": "^37.5.2",
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^141.0.0",
-    "cozy-ui-plus": "^12.3.0",
+    "cozy-ui-plus": "^12.3.12",
     "cozy-viewer": "^30.0.19",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",

--- a/src/modules/navigation/components/FilePickerButton.jsx
+++ b/src/modules/navigation/components/FilePickerButton.jsx
@@ -111,7 +111,7 @@ export const FilePickerButton = () => {
   const filePickerOptions = useMemo(
     () => ({
       ...buildFilePickerOptions(configId, t),
-      ...(themeType === 'auto' ? {} : { theme: { type: themeType } })
+      ...(themeType === 'default' ? {} : { theme: { type: themeType } })
     }),
     [configId, t, themeType]
   )
@@ -158,6 +158,12 @@ export const FilePickerButton = () => {
         value={themeType}
         onChange={event => setThemeType(event.target.value)}
       >
+        <FormControlLabel
+          key="default"
+          value="default"
+          control={<Radios />}
+          label="Theme: default"
+        />
         {filePickerThemes.map(themeOption => (
           <FormControlLabel
             key={themeOption}

--- a/src/modules/services/components/FilePicker/config.js
+++ b/src/modules/services/components/FilePicker/config.js
@@ -18,7 +18,7 @@ import { defaultFilePickerConfig, filePickerThemes } from './constants'
  * @param {object|null|undefined} intent - The intent object returned
  *   by `service.getIntent()`. Null-safe.
  * @returns {{
- *   theme: { type: 'auto'|'light'|'dark' },
+ *   theme: { type: 'light'|'dark'|undefined },
  *   multiple: boolean,
  *   sharingLink: object|null,
  *   downloadLink: object|null

--- a/src/modules/services/components/FilePicker/config.spec.js
+++ b/src/modules/services/components/FilePicker/config.spec.js
@@ -19,10 +19,10 @@ describe('FilePicker config', () => {
     })
 
     it('uses the automatic theme by default', () => {
-      expect(getFilePickerConfig(null).theme.type).toBe('auto')
+      expect(getFilePickerConfig(null).theme.type).toBe(undefined)
     })
 
-    it.each(['auto', 'light', 'dark'])('preserves the %s theme', theme => {
+    it.each([undefined, 'light', 'dark'])('preserves the %s theme', theme => {
       const intent = {
         attributes: { data: { theme: { type: theme } } }
       }
@@ -30,13 +30,16 @@ describe('FilePicker config', () => {
       expect(getFilePickerConfig(intent).theme.type).toBe(theme)
     })
 
-    it.each([null, 'sepia'])('falls back to auto for the %s theme', theme => {
-      const intent = {
-        attributes: { data: { theme: { type: theme } } }
-      }
+    it.each([null, 'sepia'])(
+      'falls back to undefined for the %s theme',
+      theme => {
+        const intent = {
+          attributes: { data: { theme: { type: theme } } }
+        }
 
-      expect(getFilePickerConfig(intent).theme.type).toBe('auto')
-    })
+        expect(getFilePickerConfig(intent).theme.type).toBe(undefined)
+      }
+    )
 
     it('reads the theme from service data', () => {
       expect(

--- a/src/modules/services/components/FilePicker/constants.js
+++ b/src/modules/services/components/FilePicker/constants.js
@@ -15,7 +15,7 @@ export const filePickerLinkModes = {
   TEMPORARY_DOWNLOAD_LINK: 'temporary-download-link'
 }
 
-export const filePickerThemes = ['auto', 'light', 'dark']
+export const filePickerThemes = ['light', 'dark']
 
 export const filePickerSharingLinkStatuses = {
   FOUND: 'found',
@@ -50,7 +50,7 @@ export const filePickerErrorCodes = {
  * folder is not meaningful for an attachment use case).
  */
 export const defaultFilePickerConfig = {
-  theme: { type: 'auto' },
+  theme: { type: undefined },
   multiple: true,
   sharingLink: { allowFolder: true },
   downloadLink: { allowFolder: false }

--- a/src/modules/services/components/IntentHandler.jsx
+++ b/src/modules/services/components/IntentHandler.jsx
@@ -107,7 +107,6 @@ const IntentHandler = ({ intentId }) => {
     <CozyTheme
       className="u-h-100 u-w-100"
       type={themeType}
-      ignoreCozySettings
       ignoreItself={false}
     >
       <BreakpointsProvider parentBasedIframe>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11714,7 +11714,7 @@ __metadata:
     cozy-stack-client: "npm:^60.28.0"
     cozy-tsconfig: "npm:^1.8.1"
     cozy-ui: "npm:^141.0.0"
-    cozy-ui-plus: "npm:^12.3.0"
+    cozy-ui-plus: "npm:^12.3.12"
     cozy-viewer: "npm:^30.0.19"
     css-mediaquery: "npm:0.1.2"
     date-fns: "npm:2.30.0"
@@ -12127,9 +12127,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-ui-plus@npm:^12.3.0":
-  version: 12.3.0
-  resolution: "cozy-ui-plus@npm:12.3.0"
+"cozy-ui-plus@npm:^12.3.12":
+  version: 12.3.12
+  resolution: "cozy-ui-plus@npm:12.3.12"
   dependencies:
     classnames: "npm:^2.5.1"
     filesize: "npm:8.0.7"
@@ -12153,7 +12153,7 @@ __metadata:
     react: ^16 || ^17 || ^18
     react-dom: ^16 || ^17 || ^18
     twake-i18n: ">=0.3.0"
-  checksum: 10/63a6c18404e8035a54d856f8e6bc122c81f949e385253818dcdfcfd6403315a80179f777c6bd46e3a028922e1f56a5dc8d524e9e42c62b399aa52c4afab7c100
+  checksum: 10/da94dd142cef32b143f4f0b93678c8e069d4a299610648e457b9b190d53c7699459ef49921b25808c2a4d1a5c0d4874573a9720b677c68d161ad2a652a8356a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/c983063d-ffbb-4260-9380-1721c4c98c34



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Theme: default” option to File Picker settings.
  * Default theme behavior follows the instance theme, with system-scheme fallback.

* **Updates**
  * File Picker theme choices are now limited to Light, Dark, or Default.
  * Removed support for the Auto theme option.
  * Invalid, omitted, or undefined theme values now use the default behavior.
  * Documented that explicitly providing a known theme can help prevent unexpected theme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->