### PR TITLE
fix(upload): preserve shared drive destination

### DIFF
--- a/src/components/Error/Empty.jsx
+++ b/src/components/Error/Empty.jsx
@@ -14,7 +14,7 @@ import TrashIllustration from '@/assets/icons/illu-trash-empty.svg'
 import { TRASH_DIR_ID } from '@/constants/config'
 import { useCurrentFolderId, useDisplayedFolder } from '@/hooks'
 import { useSharedDriveFolder } from '@/modules/shareddrives/hooks/useSharedDriveFolder'
-import UploadButton from '@/modules/upload/UploadButton'
+import { UploadButton } from '@/modules/upload/UploadButton'
 import { isSharingsTabRootRoute } from '@/modules/views/Sharings/routes'
 
 const EmptyCanvas = ({

--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Outlet, useNavigate } from 'react-router-dom'
+import { Outlet, useNavigate, useParams } from 'react-router-dom'
 
 import { BarComponent } from 'cozy-bar'
 import CozyDevtools from 'cozy-devtools'
@@ -32,7 +32,7 @@ import {
 } from '@/modules/navigation/duck/reducer'
 import { SelectionProvider } from '@/modules/selection/SelectionProvider'
 import { NewItemHighlightProvider } from '@/modules/upload/NewItemHighlightProvider'
-import UploadButton from '@/modules/upload/UploadButton'
+import { UploadButton } from '@/modules/upload/UploadButton'
 import UploadQueue from '@/modules/upload/UploadQueue'
 
 initFlags()
@@ -55,6 +55,7 @@ const LayoutContent = () => {
   const { displayedFolder } = useDisplayedFolder()
   const { t } = useI18n()
   const rawFolderId = useCurrentFolderId()
+  const { driveId } = useParams()
 
   const shouldRedirect = useSelector(wasOperationRedirected)
   const [, setLastClicked] = useNavContext()
@@ -129,6 +130,8 @@ const LayoutContent = () => {
                 </AddMenuProvider>
                 <UploadButton
                   disabled={isReadOnly}
+                  folderId={rawFolderId}
+                  driveId={driveId}
                   componentsProps={{
                     button: {
                       className: 'u-w-100 u-bdrs-6 u-fz-small',

--- a/src/modules/public/PublicToolbarByLink.jsx
+++ b/src/modules/public/PublicToolbarByLink.jsx
@@ -15,7 +15,7 @@ import AddButton from '@/modules/drive/Toolbar/components/AddButton'
 import ViewSwitcher from '@/modules/drive/Toolbar/components/ViewSwitcher'
 import PublicToolbarMoreMenu from '@/modules/public/PublicToolbarMoreMenu'
 import { useSelectionContext } from '@/modules/selection/SelectionProvider'
-import UploadButton from '@/modules/upload/UploadButton'
+import { UploadButton } from '@/modules/upload/UploadButton'
 
 const PublicToolbarByLink = ({
   files,

--- a/src/modules/upload/UploadButton.jsx
+++ b/src/modules/upload/UploadButton.jsx
@@ -14,12 +14,13 @@ import { uploadFiles } from '@/modules/navigation/duck'
 import { usePublicContext } from '@/modules/public/PublicProvider'
 import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
 
-const UploadButton = ({
+const UploadButtonBase = ({
   label,
   disabled,
   className,
   displayedFolder,
   folderId,
+  driveId,
   sharingState,
   componentsProps,
   onUploaded,
@@ -31,8 +32,10 @@ const UploadButton = ({
   const dispatch = useDispatch()
   const client = useClient()
 
-  // Explicit folderId (e.g. null on no-folder sections) overrides displayedFolder.id.
+  // Route identifiers remain available when proxied folders have no local document.
   const dirId = folderId !== undefined ? folderId : displayedFolder?.id
+  const targetDriveId =
+    driveId !== undefined ? driveId : displayedFolder?.driveId
 
   const onUpload = files => {
     onUploadStart?.()
@@ -43,7 +46,7 @@ const UploadButton = ({
         sharingState,
         onUploaded,
         { client, showAlert, t },
-        displayedFolder?.driveId,
+        targetDriveId,
         addItems
       )
     )
@@ -89,7 +92,7 @@ const UploadButton = ({
   )
 }
 
-UploadButton.propTypes = {
+UploadButtonBase.propTypes = {
   label: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   className: PropTypes.string,
@@ -97,13 +100,16 @@ UploadButton.propTypes = {
   onUploaded: PropTypes.func,
   displayedFolder: PropTypes.object, // io.cozy.files
   folderId: PropTypes.string,
+  driveId: PropTypes.string,
   onUploadStart: PropTypes.func,
   // in case of upload conflicts, shared files are not overridden
   sharingState: PropTypes.object.isRequired
 }
 
-UploadButton.defaultProps = {
+UploadButtonBase.defaultProps = {
   disabled: false
 }
 
-export default withSharingState(UploadButton)
+const UploadButton = withSharingState(UploadButtonBase)
+
+export { UploadButton, UploadButtonBase }

--- a/src/modules/upload/UploadButton.spec.jsx
+++ b/src/modules/upload/UploadButton.spec.jsx
@@ -1,0 +1,116 @@
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import { useDispatch } from 'react-redux'
+
+import { useClient } from 'cozy-client'
+import { useAlert } from 'cozy-ui/transpiled/react/providers/Alert'
+import { useI18n } from 'twake-i18n'
+
+import { UploadButtonBase } from './UploadButton'
+
+import { uploadFiles } from '@/modules/navigation/duck'
+import { useNewItemHighlightContext } from '@/modules/upload/NewItemHighlightProvider'
+
+jest.mock('@linagora/twake-icons', () => ({
+  Icon: () => null,
+  Upload: 'upload'
+}))
+jest.mock('react-redux', () => ({ useDispatch: jest.fn() }))
+jest.mock('cozy-client', () => ({ useClient: jest.fn() }))
+jest.mock(
+  'cozy-sharing/dist/hoc/withSharingState',
+  () => component => component
+)
+jest.mock('cozy-ui/transpiled/react/Buttons', () => ({ label }) => (
+  <span>{label}</span>
+))
+jest.mock(
+  'cozy-ui/transpiled/react/FileInput',
+  () =>
+    function FileInput({ children, onChange }) {
+      const handleClick = () => onChange(['file'])
+      return (
+        <button data-testid="upload-btn" onClick={handleClick}>
+          {children}
+        </button>
+      )
+    }
+)
+jest.mock('cozy-ui/transpiled/react/providers/Alert', () => ({
+  useAlert: jest.fn()
+}))
+jest.mock('twake-i18n', () => ({ useI18n: jest.fn() }))
+jest.mock('@/modules/navigation/duck', () => ({ uploadFiles: jest.fn() }))
+jest.mock('@/modules/public/PublicProvider', () => ({
+  usePublicContext: () => ({ isPublic: false })
+}))
+jest.mock('@/modules/upload/NewItemHighlightProvider', () => ({
+  useNewItemHighlightContext: jest.fn()
+}))
+
+describe('UploadButton', () => {
+  const client = { id: 'client' }
+  const sharingState = { id: 'sharing-state' }
+  const showAlert = jest.fn()
+  const t = jest.fn()
+  const addItems = jest.fn()
+  const onUploaded = jest.fn()
+  const dispatch = jest.fn()
+
+  function setup(props = {}) {
+    return render(
+      <UploadButtonBase
+        label="Upload"
+        displayedFolder={{ id: 'document-folder', driveId: 'document-drive' }}
+        sharingState={sharingState}
+        onUploaded={onUploaded}
+        {...props}
+      />
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useClient.mockReturnValue(client)
+    useDispatch.mockReturnValue(dispatch)
+    useAlert.mockReturnValue({ showAlert })
+    useI18n.mockReturnValue({ t })
+    useNewItemHighlightContext.mockReturnValue({ addItems })
+    uploadFiles.mockReturnValue({ type: 'UPLOAD_FILES' })
+  })
+
+  it('uses route identifiers for a proxied shared-drive folder', () => {
+    const { getByTestId } = setup({
+      folderId: 'route-folder',
+      driveId: 'route-drive'
+    })
+
+    fireEvent.click(getByTestId('upload-btn'))
+
+    expect(uploadFiles).toHaveBeenCalledWith(
+      ['file'],
+      'route-folder',
+      sharingState,
+      onUploaded,
+      { client, showAlert, t },
+      'route-drive',
+      addItems
+    )
+  })
+
+  it('falls back to identifiers from the displayed folder', () => {
+    const { getByTestId } = setup()
+
+    fireEvent.click(getByTestId('upload-btn'))
+
+    expect(uploadFiles).toHaveBeenCalledWith(
+      ['file'],
+      'document-folder',
+      sharingState,
+      onUploaded,
+      { client, showAlert, t },
+      'document-drive',
+      addItems
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- pass route folder and drive identifiers from Layout to the sidebar UploadButton
- prefer explicit destination properties for shared-drive uploads while keeping displayedFolder as the fallback
- cover explicit and fallback destination selection

Uploads previously appeared reliable because displayedFolder usually resolved before users could interact. Shared-drive contents and the Layout displayed-folder query load independently, so an empty folder can expose Upload first and make uploadFiles fall back to the local root.