### PR TITLE
fix(filters): use contact search clear button

### DIFF
--- a/src/components/Filters/ContactFilter.spec.tsx
+++ b/src/components/Filters/ContactFilter.spec.tsx
@@ -2,7 +2,8 @@ import {
   fireEvent,
   render,
   screen,
-  type RenderResult
+  type RenderResult,
+  within
 } from '@testing-library/react'
 import React from 'react'
 
@@ -153,6 +154,23 @@ describe('ContactFilter', () => {
       screen.queryByRole('option', { name: /Thomas Jolly/ })
     ).toBeInTheDocument()
     expect(screen.queryByRole('option', { name: /Élodie Martin/ })).toBe(null)
+  })
+
+  it('clears the contact search through the clear button', () => {
+    renderContactFilter()
+    openContactFilter()
+
+    const searchInput = screen.getByRole('searchbox', { name: 'Search' })
+    fireEvent.change(searchInput, { target: { value: 'elodie' } })
+
+    const searchForm = searchInput.closest('form')
+    if (searchForm === null) throw new Error('Search form not found')
+
+    fireEvent.click(within(searchForm).getByRole('button'))
+
+    expect(searchInput).toHaveValue('')
+    expect(within(searchForm).queryByRole('button')).toBe(null)
+    expect(screen.queryAllByRole('option')).toHaveLength(OPTIONS.length)
   })
 
   it('limits suggestions and finds options beyond the limit through search', () => {

--- a/src/components/Filters/ContactFilter.styl
+++ b/src/components/Filters/ContactFilter.styl
@@ -9,10 +9,6 @@
     width 20rem
     max-width calc(100vw - 2rem)
 
-.searchInput
-    input[type='search']::-webkit-search-cancel-button // @stylint ignore
-        margin-right .5rem
-
 .suggestionsList
     max-height 17.5rem
     overflow-y auto

--- a/src/components/Filters/ContactFilterSearchInput.tsx
+++ b/src/components/Filters/ContactFilterSearchInput.tsx
@@ -3,8 +3,6 @@ import type Autosuggest from 'react-autosuggest'
 
 import SearchBar from 'cozy-ui/transpiled/react/SearchBar'
 
-import styles from './ContactFilter.styl'
-
 function handleSearchSubmit(event: FormEvent<HTMLFormElement>): void {
   event.preventDefault()
 }
@@ -19,13 +17,18 @@ function ContactFilterSearchInput({
 }: Autosuggest.RenderInputComponentProps): ReactElement {
   return (
     <SearchBar
-      className={`${styles.searchInput} u-w-100`}
+      className="u-w-100"
       componentsProps={{
         inputBase: {
-          inputProps
+          inputProps: {
+            ...inputProps,
+            role: 'searchbox',
+            // SearchBar provides the clear IconButton, so suppress the
+            // browser-native search clear control.
+            type: 'text'
+          }
         }
       }}
-      disabledClear
       elevation={0}
       onBlur={onBlur}
       onChange={onChange}


### PR DESCRIPTION
## Summary

- Use the SearchBar IconButton to clear contact search queries.
- Prevent the browser from rendering a duplicate native clear control.
- Remove the browser-specific cancel-button styling and test the clear interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact filter search behavior and accessibility.
  * Clearing the search now resets the input, removes the clear control, and restores the full list of options.
  * Removed the browser-native search cancel control for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->