### PR TITLE
fix(filters): enlarge contact suggestion avatars

### DIFF
--- a/src/modules/views/Sharings/SharingsFilters.tsx
+++ b/src/modules/views/Sharings/SharingsFilters.tsx
@@ -60,9 +60,9 @@ function SharingsFilters({
     option => ({
       avatar:
         option.kind === 'person' ? (
-          <MemberAvatar recipient={option.recipient} size="s" />
+          <MemberAvatar recipient={option.recipient} size="m" />
         ) : (
-          <GroupAvatar color={option.recipient.color} size="s" />
+          <GroupAvatar color={option.recipient.color} size="m" />
         ),
       label: option.label,
       searchableValues: option.searchableValues,


### PR DESCRIPTION
## Summary

- Render person and group avatars at the 32px contact-list size.