### PR TITLE
fix(filters): use secondary empty-state color

### DIFF
--- a/src/components/Filters/ContactFilter.spec.tsx
+++ b/src/components/Filters/ContactFilter.spec.tsx
@@ -225,6 +225,9 @@ describe('ContactFilter', () => {
     )
 
     expect(screen.queryByRole('status')).toHaveTextContent('No result')
+    expect(screen.queryByText('No result')).toHaveClass(
+      'MuiTypography-colorTextSecondary'
+    )
   })
 
   it('does not open the autocomplete from its wrapper when disabled', () => {

--- a/src/components/Filters/ContactFilterSuggestionsContainer.tsx
+++ b/src/components/Filters/ContactFilterSuggestionsContainer.tsx
@@ -2,6 +2,7 @@ import React, { type ReactElement } from 'react'
 import type Autosuggest from 'react-autosuggest'
 
 import { Spinner } from 'cozy-ui/transpiled/react/Spinner'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import styles from './ContactFilter.styl'
 
@@ -40,7 +41,9 @@ const ContactFilterSuggestionsContainer = ({
           className={`${styles.status} u-flex u-flex-items-center u-flex-justify-center u-ph-1 u-ta-center`}
           role="status"
         >
-          {emptyMessage}
+          <Typography color="textSecondary" variant="body1">
+            {emptyMessage}
+          </Typography>
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary

- Render the contact filter empty-state message with the theme text-secondary color.
- Cover the empty-state color in the contact filter test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance and styling of the “No result” message in contact filters for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->