### PR TITLE
fix(filters): align active dropdown icon color

### DIFF
--- a/src/components/Filters/Filter.jsx
+++ b/src/components/Filters/Filter.jsx
@@ -37,14 +37,12 @@ const useStyles = makeStyles(theme => ({
   },
   active: {
     '& .MuiFilledInput-root': {
+      '--iconTextColor': theme.palette.primary.main,
       color: theme.palette.primary.main,
       backgroundColor: alpha(
         theme.palette.primary.main,
         theme.palette.action.ghostOpacity
       ),
-      '& .MuiSelect-icon': {
-        color: theme.palette.primary.main
-      },
       '&.Mui-focused': {
         backgroundColor: alpha(
           theme.palette.primary.main,


### PR DESCRIPTION
## Summary

- Use the active primary color for Type and Date filter dropdown icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the active filter appearance to use the primary color consistently.
  * Improved filter icon styling for a cleaner visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->