### PR TITLE
fix(filters): restore hover after selection

### DIFF
--- a/src/components/Filters/Filter.jsx
+++ b/src/components/Filters/Filter.jsx
@@ -45,7 +45,13 @@ const useStyles = makeStyles(theme => ({
       '& .MuiSelect-icon': {
         color: theme.palette.primary.main
       },
-      '&:hover, &.Mui-focused': {
+      '&.Mui-focused': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.focusOpacity
+        )
+      },
+      '&:hover': {
         backgroundColor: alpha(
           theme.palette.primary.main,
           theme.palette.action.hoverGhostOpacity


### PR DESCRIPTION
## Summary

- Give focused active filters a distinct focus background.
- Preserve hover feedback immediately after selecting a filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved visual distinction for active filters with a dedicated focused background opacity.
  - Preserved the existing hover appearance for filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->