### PR TITLE
fix(sharings): hide filters on mobile

### DIFF
--- a/src/modules/views/Sharings/index.jsx
+++ b/src/modules/views/Sharings/index.jsx
@@ -172,11 +172,13 @@ export const SharingsView = ({ sharedDocumentIds = [] }) => {
           onChange={setTab}
           showDrives={showDrives}
         />
-        <SharingsFilters
-          {...sharingsFilters}
-          contactFilterLoading={!allLoaded}
-          contactFilterOptions={contactFilterOptions}
-        />
+        {!base.isMobile && (
+          <SharingsFilters
+            {...sharingsFilters}
+            contactFilterLoading={!allLoaded}
+            contactFilterOptions={contactFilterOptions}
+          />
+        )}
         {!allLoaded ||
         !sharedDrivesLoaded ||
         !hasQueryBeenLoaded(filteredResult) ? (

--- a/src/modules/views/Sharings/index.spec.jsx
+++ b/src/modules/views/Sharings/index.spec.jsx
@@ -72,9 +72,11 @@ const SharingsRoute = ({ tab }) => (
 const setup = ({
   initialTab = SHARING_TAB_WITH_ME,
   initialSearch = '',
-  sharedDrives = []
+  sharedDrives = [],
+  viewportWidth = 1024
 } = {}) => {
   const { store, client } = setupStoreAndClient()
+  window.innerWidth = viewportWidth
   window.location.hash = `#/sharings/${initialTab}${initialSearch}`
 
   client.plugins.realtime = {
@@ -310,6 +312,17 @@ describe('Sharings View', () => {
       expect(getByText('foobar0')).toBeInTheDocument()
     })
     expect(window.location.hash).toBe('#/sharings/with-me')
+  })
+
+  it('hides filters on mobile', async () => {
+    useQuery.mockReturnValue(filesFixtureWithPath)
+
+    const { getByRole, queryByTestId } = setup({ viewportWidth: 500 })
+
+    await waitFor(() => {
+      expect(getByRole('tab', { name: 'With me' })).toBeInTheDocument()
+    })
+    expect(queryByTestId('sharings-filters')).toBe(null)
   })
 
   describe('team drives tab visibility', () => {


### PR DESCRIPTION
## Summary

- Hide the Sharings filter toolbar on mobile viewports.
- Cover the mobile rendering behavior with an integration test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Sharings filters are now hidden on mobile screens for a cleaner, more focused experience.
  * Sharings tabs remain available on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->