### PR TITLE
fix(filters): remove duplicate contact hover

### DIFF
--- a/src/components/Filters/ContactFilter.styl
+++ b/src/components/Filters/ContactFilter.styl
@@ -14,6 +14,10 @@
     overflow-y auto
     list-style none
 
+.suggestionsContainer
+    margin-left -.5rem
+    margin-right -.5rem
+
 .suggestionHighlighted
     background-color var(--actionColorHover)
 

--- a/src/components/Filters/ContactFilter.tsx
+++ b/src/components/Filters/ContactFilter.tsx
@@ -59,10 +59,14 @@ const ContactFilter = ({
     handleClose()
   }
 
-  const renderSuggestion = (option: ContactFilterOption): ReactElement => {
+  const renderSuggestion = (
+    option: ContactFilterOption,
+    { isHighlighted }: Autosuggest.RenderSuggestionParams
+  ): ReactElement => {
     return (
       <ContactFilterSuggestion
         currentUserLabel={t('filters.contact.me')}
+        highlighted={isHighlighted}
         option={option}
       />
     )
@@ -176,9 +180,7 @@ const ContactFilter = ({
             suggestions={suggestions}
             theme={{
               container: 'u-w-100',
-              suggestion: 'u-bdrs-4',
-              suggestionHighlighted: styles.suggestionHighlighted,
-              suggestionsContainer: 'u-mt-half',
+              suggestionsContainer: `${styles.suggestionsContainer} u-mt-half`,
               suggestionsList: `${styles.suggestionsList} u-m-0 u-p-0`
             }}
           />

--- a/src/components/Filters/ContactFilterSuggestion.tsx
+++ b/src/components/Filters/ContactFilterSuggestion.tsx
@@ -4,15 +4,18 @@ import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 
+import styles from './ContactFilter.styl'
 import type { ContactFilterOption } from './ContactFilter.types'
 
 interface ContactFilterSuggestionProps {
   currentUserLabel: string
+  highlighted: boolean
   option: ContactFilterOption
 }
 
 const ContactFilterSuggestion = ({
   currentUserLabel,
+  highlighted,
   option
 }: ContactFilterSuggestionProps): ReactElement => {
   const primaryLabel = option.isCurrentUser
@@ -20,7 +23,10 @@ const ContactFilterSuggestion = ({
     : option.label
 
   return (
-    <ListItem button>
+    <ListItem
+      button
+      className={highlighted ? styles.suggestionHighlighted : undefined}
+    >
       <ListItemIcon>{option.avatar}</ListItemIcon>
       <ListItemText primary={primaryLabel} secondary={option.secondaryLabel} />
     </ListItem>


### PR DESCRIPTION
## Summary

- Apply the contact suggestion highlight to the list row instead of its wrapper.
- Make the hover background span the full dropdown width.
- Remove the overlapping hover layers and unintended rounded suggestion shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved contact filter suggestions with clearer visual highlighting for the currently selected option.
  * Adjusted suggestion menu spacing for a more polished layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->