### PR TITLE
fix(sharings): preserve filters around share modal

### DIFF
--- a/src/modules/actions/helpers.js
+++ b/src/modules/actions/helpers.js
@@ -1,11 +1,21 @@
 import { joinPath } from '@/lib/path'
 
-export const navigateToModal = ({ navigate, pathname, files, path }) => {
+export const navigateToModal = ({
+  navigate,
+  pathname,
+  search = '',
+  files,
+  path
+}) => {
   const file = Array.isArray(files) ? files[0] : files
+  const targetPathname = pathname
+    ? joinPath(pathname, `file/${file.id}/${path}`)
+    : `v/${path}`
+  const targetLocation = search
+    ? { pathname: targetPathname, search }
+    : targetPathname
 
-  return navigate(
-    pathname ? joinPath(pathname, `file/${file.id}/${path}`) : `v/${path}`
-  )
+  return navigate(targetLocation)
 }
 
 export const navigateToModalWithMultipleFile = ({

--- a/src/modules/actions/helpers.spec.js
+++ b/src/modules/actions/helpers.spec.js
@@ -50,6 +50,21 @@ describe('actions helpers', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith('/folder/456/file/file-1/edit')
     })
+
+    it('should preserve search params when opening a modal', () => {
+      navigateToModal({
+        navigate: mockNavigate,
+        pathname: '/sharings/with-me',
+        search: '?f.contact=person%3Aalice%40example.com&f.type=document',
+        files: { id: 'file-123', name: 'test.pdf' },
+        path: 'share'
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith({
+        pathname: '/sharings/with-me/file/file-123/share',
+        search: '?f.contact=person%3Aalice%40example.com&f.type=document'
+      })
+    })
   })
 
   describe('navigateToModalWithMultipleFile', () => {

--- a/src/modules/actions/share.jsx
+++ b/src/modules/actions/share.jsx
@@ -16,6 +16,7 @@ const share = ({
   hasWriteAccess,
   navigate,
   pathname,
+  search,
   allLoaded
 }) => {
   const label = t('Files.share.cta')
@@ -41,7 +42,7 @@ const share = ({
       )
     },
     action: files =>
-      navigateToModal({ navigate, pathname, files, path: 'share' }),
+      navigateToModal({ navigate, pathname, search, files, path: 'share' }),
     Component: forwardRef(function ShareMenuItemInMenu(props, ref) {
       const { isMobile } = useBreakpoints()
 

--- a/src/modules/actions/share.spec.jsx
+++ b/src/modules/actions/share.spec.jsx
@@ -1,0 +1,23 @@
+import { share } from './share'
+
+describe('share action', () => {
+  it('preserves search params when opening the share modal', () => {
+    const navigate = jest.fn()
+    const action = share({
+      allLoaded: true,
+      hasWriteAccess: true,
+      navigate,
+      pathname: '/sharings/with-me',
+      search: '?f.contact=person%3Aalice%40example.com',
+      shouldHideIfSharedDriveRecipient: false,
+      t: key => key
+    })
+
+    action.action([{ id: 'file-id' }])
+
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/sharings/with-me/file/file-id/share',
+      search: '?f.contact=person%3Aalice%40example.com'
+    })
+  })
+})

--- a/src/modules/drive/Toolbar/share/ShareButton.jsx
+++ b/src/modules/drive/Toolbar/share/ShareButton.jsx
@@ -10,11 +10,11 @@ import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/hel
 const ShareButtonWithProps = ({ isDisabled, className, useShortLabel }) => {
   const { displayedFolder } = useDisplayedFolder()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
   const { isMobile } = useBreakpoints()
 
   const share = () => {
-    navigate(getPathToShareDisplayedFolder(pathname))
+    navigate({ pathname: getPathToShareDisplayedFolder(pathname), search })
   }
 
   if (!displayedFolder) return null

--- a/src/modules/drive/Toolbar/share/ShareItem.jsx
+++ b/src/modules/drive/Toolbar/share/ShareItem.jsx
@@ -14,10 +14,10 @@ import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/hel
 const ShareItem = ({ displayedFolder }) => {
   const { t } = useI18n()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
 
   const share = () => {
-    navigate(getPathToShareDisplayedFolder(pathname))
+    navigate({ pathname: getPathToShareDisplayedFolder(pathname), search })
   }
 
   return (

--- a/src/modules/drive/Toolbar/share/SharedRecipients.jsx
+++ b/src/modules/drive/Toolbar/share/SharedRecipients.jsx
@@ -9,10 +9,10 @@ import { getPathToShareDisplayedFolder } from '@/modules/drive/Toolbar/share/hel
 const SharedRecipientsComponent = () => {
   const { displayedFolder } = useDisplayedFolder()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
 
   const share = () => {
-    navigate(getPathToShareDisplayedFolder(pathname))
+    navigate({ pathname: getPathToShareDisplayedFolder(pathname), search })
   }
 
   return (

--- a/src/modules/filelist/useFileShareNavigate.js
+++ b/src/modules/filelist/useFileShareNavigate.js
@@ -4,7 +4,7 @@ import { makeFileSharePath } from '@/modules/filelist/sharePath'
 
 export const useFileShareNavigate = ({ file, disabled }) => {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
 
   return e => {
     // Avoid triggering row click from FileOpener.
@@ -12,7 +12,7 @@ export const useFileShareNavigate = ({ file, disabled }) => {
     e.stopPropagation()
 
     if (!disabled) {
-      navigate(makeFileSharePath({ file, pathname }))
+      navigate({ pathname: makeFileSharePath({ file, pathname }), search })
     }
   }
 }

--- a/src/modules/filelist/useFileShareNavigate.spec.js
+++ b/src/modules/filelist/useFileShareNavigate.spec.js
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useFileShareNavigate } from './useFileShareNavigate'
+
+const mockNavigate = jest.fn()
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    pathname: '/sharings/with-me',
+    search: '?f.type=document'
+  }),
+  useNavigate: () => mockNavigate
+}))
+
+describe('useFileShareNavigate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('preserves search params when opening the share modal', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    }
+    const { result } = renderHook(() =>
+      useFileShareNavigate({ file: { id: 'file-id' }, disabled: false })
+    )
+
+    act(() => result.current(event))
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/sharings/with-me/file/file-id/share',
+      search: '?f.type=document'
+    })
+  })
+})

--- a/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.js
@@ -14,7 +14,8 @@ export const shareFileRootSharedDrive = ({
   navigate,
   t,
   isOwner,
-  pathname
+  pathname,
+  search = ''
 }) => {
   const label = t('Files.share.cta')
   const icon = Share
@@ -33,7 +34,10 @@ export const shareFileRootSharedDrive = ({
     // Same route the avatars build, so the share button layers the modal over
     // the sharings list instead of navigating into the shared-drive view.
     action: docs => {
-      navigate(makeFileSharePath({ file: docs[0], pathname }))
+      navigate({
+        pathname: makeFileSharePath({ file: docs[0], pathname }),
+        search
+      })
     },
     Component: forwardRef(function ShareFileRootSharedDrive(props, ref) {
       return (

--- a/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.spec.js
+++ b/src/modules/shareddrives/components/actions/shareFileRootSharedDrive.spec.js
@@ -8,8 +8,10 @@ describe('shareFileRootSharedDrive', () => {
 
   const makeAction = ({
     isOwner = () => true,
-    pathname = '/sharings/drives'
-  } = {}) => shareFileRootSharedDrive({ navigate, t, isOwner, pathname })
+    pathname = '/sharings/drives',
+    search = ''
+  } = {}) =>
+    shareFileRootSharedDrive({ navigate, t, isOwner, pathname, search })
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -35,9 +37,10 @@ describe('shareFileRootSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/sharings/drives/shareddrive/drive-id/file-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/sharings/drives/shareddrive/drive-id/file-id/share',
+      search: ''
+    })
   })
 
   it('navigates to the direct share route when pathname is outside /sharings', () => {
@@ -49,8 +52,9 @@ describe('shareFileRootSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/shareddrive/drive-id/file/file-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/shareddrive/drive-id/file/file-id/share',
+      search: ''
+    })
   })
 })

--- a/src/modules/shareddrives/components/actions/shareSharedDrive.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.js
@@ -13,7 +13,7 @@ import { isFileRootSharedDrive } from '@/modules/shareddrives/rootFileNavigation
 // drives are handled by `shareFileRootSharedDrive`. The two are mutually
 // exclusive: this one hides itself when the doc is a file-root, and the
 // file-root one only shows for file-roots.
-export const shareSharedDrive = ({ navigate, t, pathname }) => {
+export const shareSharedDrive = ({ navigate, t, pathname, search = '' }) => {
   const label = t('Files.share.cta')
   const icon = Share
 
@@ -33,7 +33,10 @@ export const shareSharedDrive = ({ navigate, t, pathname }) => {
     // Same route the avatars build, so the share button layers the modal over
     // the sharings list instead of navigating into the shared-drive view.
     action: docs => {
-      navigate(makeFileSharePath({ file: docs[0], pathname }))
+      navigate({
+        pathname: makeFileSharePath({ file: docs[0], pathname }),
+        search
+      })
     },
     Component: forwardRef(function ShareSharedDrive(props, ref) {
       return (

--- a/src/modules/shareddrives/components/actions/shareSharedDrive.spec.js
+++ b/src/modules/shareddrives/components/actions/shareSharedDrive.spec.js
@@ -6,8 +6,11 @@ describe('shareSharedDrive', () => {
   const t = key => key
   const navigate = jest.fn()
 
-  const makeAction = ({ isOwner, pathname = '/sharings/drives' } = {}) =>
-    shareSharedDrive({ navigate, t, isOwner, pathname })
+  const makeAction = ({
+    isOwner,
+    pathname = '/sharings/drives',
+    search = ''
+  } = {}) => shareSharedDrive({ navigate, t, isOwner, pathname, search })
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -51,9 +54,10 @@ describe('shareSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/sharings/drives/shareddrive/drive-id/folder-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/sharings/drives/shareddrive/drive-id/folder-id/share',
+      search: ''
+    })
   })
 
   it('opens the folder view share modal when outside /sharings', () => {
@@ -65,8 +69,9 @@ describe('shareSharedDrive', () => {
       }
     ])
 
-    expect(navigate).toHaveBeenCalledWith(
-      '/shareddrive/drive-id/folder-id/file/folder-id/share'
-    )
+    expect(navigate).toHaveBeenCalledWith({
+      pathname: '/shareddrive/drive-id/folder-id/file/folder-id/share',
+      search: ''
+    })
   })
 })

--- a/src/modules/viewer/FilesViewer.jsx
+++ b/src/modules/viewer/FilesViewer.jsx
@@ -221,6 +221,7 @@ const FilesViewer = ({ filesQuery, files, onClose, onChange, viewerProps }) => {
                     navigateToModal({
                       navigate,
                       pathname: '',
+                      search: location.search,
                       files,
                       path: 'share'
                     })

--- a/src/modules/views/Folder/hooks/useFolderViewBase.js
+++ b/src/modules/views/Folder/hooks/useFolderViewBase.js
@@ -18,7 +18,7 @@ import { useSelectionContext } from '@/modules/selection/SelectionProvider'
  */
 export const useFolderViewBase = () => {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
   const { isMobile } = useBreakpoints()
   const { t, lang } = useI18n()
   const client = useClient()
@@ -31,6 +31,7 @@ export const useFolderViewBase = () => {
   return {
     navigate,
     pathname,
+    search,
     isMobile,
     t,
     lang,

--- a/src/modules/views/Modal/ShareDisplayedFolderView.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.jsx
@@ -10,11 +10,11 @@ import { getSharingsRootRoute } from '@/modules/views/Sharings/routes'
 const ShareDisplayedFolderView = () => {
   const { displayedFolder } = useDisplayedFolder()
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
 
   if (displayedFolder) {
     const onClose = () => {
-      navigate('..', { replace: true })
+      navigate({ pathname: '..', search }, { replace: true })
     }
 
     const onRevokeSuccess = () => {

--- a/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
+++ b/src/modules/views/Modal/ShareDisplayedFolderView.spec.jsx
@@ -32,7 +32,10 @@ jest.mock('@/hooks', () => ({
 describe('ShareDisplayedFolderView', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseLocation.mockReturnValue({ pathname: '/folder/folder-id/share' })
+    mockUseLocation.mockReturnValue({
+      pathname: '/folder/folder-id/share',
+      search: ''
+    })
   })
 
   it('should redirect to the active tab after leaving a shared drive', () => {
@@ -75,7 +78,11 @@ describe('ShareDisplayedFolderView', () => {
     )
   })
 
-  it('should keep passing onClose to the share modal', () => {
+  it('should preserve search params when closing the share modal', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings/with-me/folder/folder-id/share',
+      search: '?f.type=directory&f.date=last-month'
+    })
     useDisplayedFolder.mockReturnValue({
       displayedFolder: {
         name: 'Shared folder'
@@ -86,6 +93,12 @@ describe('ShareDisplayedFolderView', () => {
 
     ShareModal.mock.calls[0][0].onClose()
 
-    expect(mockNavigate).toHaveBeenCalledWith('..', { replace: true })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      {
+        pathname: '..',
+        search: '?f.type=directory&f.date=last-month'
+      },
+      { replace: true }
+    )
   })
 })

--- a/src/modules/views/Modal/ShareFileView.jsx
+++ b/src/modules/views/Modal/ShareFileView.jsx
@@ -14,7 +14,7 @@ import {
 
 const ShareFileView = () => {
   const navigate = useNavigate()
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
   const { fileId, driveId } = useParams()
 
   const fileQuery = driveId
@@ -23,7 +23,7 @@ const ShareFileView = () => {
   const fileResult = useQuery(fileQuery.definition, fileQuery.options)
 
   const handleExit = () => {
-    navigate('..', { replace: true })
+    navigate({ pathname: '..', search }, { replace: true })
   }
 
   const handleRevokeSuccess = () => {

--- a/src/modules/views/Modal/ShareFileView.spec.jsx
+++ b/src/modules/views/Modal/ShareFileView.spec.jsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { hasQueryBeenLoaded, useQuery } from 'cozy-client'
+import { ShareModal } from 'cozy-sharing'
 
 import { ShareFileView } from './ShareFileView'
 
@@ -51,7 +52,10 @@ jest.mock('@/queries', () => ({
 describe('ShareFileView', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseLocation.mockReturnValue({ pathname: '/folder/folder-id' })
+    mockUseLocation.mockReturnValue({
+      pathname: '/folder/folder-id',
+      search: ''
+    })
     hasQueryBeenLoaded.mockReturnValue(true)
     useQuery.mockReturnValue({
       data: {
@@ -89,6 +93,26 @@ describe('ShareFileView', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       `/sharings/${SHARING_TAB_WITH_ME}`,
+      { replace: true }
+    )
+  })
+
+  it('should preserve search params when closing the modal', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/sharings/with-me/file/file-id/share',
+      search: '?f.contact=person%3Aalice%40example.com'
+    })
+    mockUseParams.mockReturnValue({ fileId: 'file-id' })
+
+    render(<ShareFileView />)
+
+    ShareModal.mock.calls[0][0].onClose()
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      {
+        pathname: '..',
+        search: '?f.contact=person%3Aalice%40example.com'
+      },
       { replace: true }
     )
   })

--- a/src/modules/views/Public/PublicFolderView.jsx
+++ b/src/modules/views/Public/PublicFolderView.jsx
@@ -78,7 +78,7 @@ const getBreadcrumbPath = async ({
 const PublicFolderView = ({ sharedDocumentId }) => {
   const base = useFolderViewBase()
   const { navigate, pathname } = base
-  // `state` is on useLocation; useFolderViewBase only forwards pathname.
+  // `state` is read separately because useFolderViewBase does not forward it.
   const { state } = useLocation()
   const currentFolderId = useCurrentFolderId()
   const { displayedFolder } = useDisplayedFolder()


### PR DESCRIPTION
## Summary

- Preserve sharing filter query parameters while opening and closing Share dialogs.
- Cover row, avatar, toolbar, viewer, and shared-drive Share entry points.
- Add navigation regression tests for filtered sharing routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved URL query parameters when opening, closing, and navigating through file and folder sharing views.
  * Maintained active filters and search settings across share modals, shared drives, and folder navigation.

* **Tests**
  * Added and updated coverage to verify query parameters remain intact during sharing-related navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->