### PR TITLE
test(sharings): cover filtered federated re-sharing

### DIFF
--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -12,14 +12,14 @@ export const RESET = process.env.E2E_RESET === '1'
 export const ADMIN_USER = 'admin'
 export const ADMIN_PASSPHRASE = 'cozy'
 
-// Tying both instances to the same (OrgID, OrgDomain) makes them count as
+// Tying all instances to the same (OrgID, OrgDomain) makes them count as
 // trusted contacts of each other for cozy-to-cozy sharing — combined with the
 // `auto_accept_trusted_contacts` context option, invitations no longer need
 // an SMTP delivery to be accepted.
 export const ORG_ID = 'twake-drive-e2e'
 export const ORG_DOMAIN = 'cozy.localhost'
 
-export type UserLabel = 'alice' | 'bob'
+export type UserLabel = 'alice' | 'bob' | 'charlie'
 
 export interface User {
   label: UserLabel
@@ -45,6 +45,13 @@ export const USERS: Record<UserLabel, User> = {
     appUrl: `http://bob-drive.cozy.localhost${instancePortSuffix}`,
     email: 'bob@cozy.localhost',
     passphrase: 'bob1234'
+  },
+  charlie: {
+    label: 'charlie',
+    instance: `charlie.cozy.localhost${instancePortSuffix}`,
+    appUrl: `http://charlie-drive.cozy.localhost${instancePortSuffix}`,
+    email: 'charlie@cozy.localhost',
+    passphrase: 'charlie1234'
   }
 }
 

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -9,13 +9,16 @@ import type {
 } from '@playwright/test'
 
 import { authenticate } from './auth'
+import type { UserLabel } from './config'
 import { DrivePage } from '../pages/DrivePage'
 
 type AuthedFixtures = {
   alicePage: Page
   bobPage: Page
+  charliePage: Page
   aliceDrive: DrivePage
   bobDrive: DrivePage
+  charlieDrive: DrivePage
 }
 
 type ContextFixtures = {
@@ -42,7 +45,7 @@ const attachIfAny = async (
 }
 
 const userPageFixture =
-  (user: 'alice' | 'bob') =>
+  (user: UserLabel) =>
   async (
     { browser, contextOptions }: ContextFixtures,
     use: (page: Page) => Promise<void>,
@@ -79,11 +82,15 @@ const userPageFixture =
 export const test = base.extend<AuthedFixtures>({
   alicePage: userPageFixture('alice'),
   bobPage: userPageFixture('bob'),
+  charliePage: userPageFixture('charlie'),
   aliceDrive: async ({ alicePage }, use) => {
     await use(new DrivePage(alicePage))
   },
   bobDrive: async ({ bobPage }, use) => {
     await use(new DrivePage(bobPage))
+  },
+  charlieDrive: async ({ charliePage }, use) => {
+    await use(new DrivePage(charliePage))
   }
 })
 

--- a/e2e/tests/z-sharing-filters.spec.ts
+++ b/e2e/tests/z-sharing-filters.spec.ts
@@ -1,0 +1,93 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import { expect, safeUnlink, stamp, test } from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  waitForSharingRow
+} from '../helpers/sharing'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+const DOCUMENT_NAME = `filtered-reshare-${stamp()}.txt`
+const FOLDER_NAME = `Filtered Reshare Folder ${stamp()}`
+const DOCUMENT_MARKER = 'before-reshare'
+
+test.describe.serial('Filtered federated re-sharing', () => {
+  test('Alice shares a document and a folder with Bob', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const documentPath = path.join(FIXTURE_DIR, DOCUMENT_NAME)
+    await copyFile(SAMPLE, documentPath)
+    try {
+      await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+      await aliceDrive.uploadFiles(documentPath)
+      const documentRow = aliceDrive.row(DOCUMENT_NAME)
+      await documentRow.waitVisible()
+
+      const shareModal = await documentRow.share()
+      await shareModal.addMember(USERS.bob.email)
+      await shareModal.share()
+    } finally {
+      await safeUnlink(documentPath)
+    }
+
+    await createAndShareFolderWithBob(alicePage, aliceDrive, FOLDER_NAME)
+  })
+
+  test('Bob keeps his folder filter while re-sharing live with Charlie', async ({
+    bobPage,
+    bobDrive,
+    charliePage,
+    charlieDrive
+  }) => {
+    await waitForSharingRow(bobPage, USERS.bob, bobDrive, DOCUMENT_NAME)
+    await waitForSharingRow(bobPage, USERS.bob, bobDrive, FOLDER_NAME)
+
+    await charliePage.goto(`${USERS.charlie.appUrl}/#/sharings/with-me`)
+    await expect(charliePage.getByTestId('sharings-filters')).toBeVisible()
+    await expect(charlieDrive.row(FOLDER_NAME).cell).toHaveCount(0)
+    await charliePage.locator('html').evaluate((root, marker) => {
+      root.dataset.e2eDocumentMarker = marker
+    }, DOCUMENT_MARKER)
+
+    await bobPage.getByRole('button', { name: 'Type', exact: true }).click()
+    await bobPage.getByRole('option', { name: 'Folders' }).click()
+
+    await expect(bobPage).toHaveURL(
+      /#\/sharings\/with-me\?f\.type=directory$/
+    )
+    await expect(
+      bobPage.getByRole('button', { name: 'Folders', exact: true })
+    ).toBeVisible()
+    await expect(bobDrive.row(FOLDER_NAME).cell).toBeVisible()
+    await expect(bobDrive.row(DOCUMENT_NAME).cell).toHaveCount(0)
+
+    const shareModal = await bobDrive.row(FOLDER_NAME).share()
+    await expect(bobPage).toHaveURL(
+      /#\/sharings\/with-me\/shareddrive\/[^/]+\/[^/]+\/share\?f\.type=directory$/
+    )
+    await shareModal.addMember(USERS.charlie.email)
+    await shareModal.share()
+
+    await expect(bobPage).toHaveURL(
+      /#\/sharings\/with-me\?f\.type=directory$/
+    )
+    await expect(
+      bobPage.getByRole('button', { name: 'Folders', exact: true })
+    ).toBeVisible()
+    await expect(bobDrive.row(FOLDER_NAME).cell).toBeVisible()
+    await expect(bobDrive.row(DOCUMENT_NAME).cell).toHaveCount(0)
+
+    await expect(charlieDrive.row(FOLDER_NAME).cell).toBeVisible({
+      timeout: 30_000
+    })
+    await expect(charliePage).toHaveURL(/#\/sharings\/with-me$/)
+    await expect(charliePage.locator('html')).toHaveAttribute(
+      'data-e2e-document-marker',
+      DOCUMENT_MARKER
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Provision Charlie as a third federated E2E user with trusted contacts.
- Cover filtering the With me tab to folders and preserving that filter through re-sharing.
- Verify the new recipient receives the shared folder on an already-open page without a reload.