### PR TITLE
chore(deps): upgrade cozy-sharing and cozy-viewer for icon fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^141.0.0",
     "cozy-ui-plus": "^12.3.12",
-    "cozy-viewer": "^30.0.19",
+    "cozy-viewer": "^30.0.38",
     "date-fns": "2.30.0",
     "diacritics": "1.3.0",
     "filesize": "10.1.6",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "cozy-pouch-link": "^60.29.0",
     "cozy-realtime": "^5.9.3",
     "cozy-search": "^2.2.18",
-    "cozy-sharing": "^37.5.2",
+    "cozy-sharing": "^37.5.4",
     "cozy-stack-client": "^60.28.0",
     "cozy-ui": "^141.0.0",
     "cozy-ui-plus": "^12.3.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11715,7 +11715,7 @@ __metadata:
     cozy-tsconfig: "npm:^1.8.1"
     cozy-ui: "npm:^141.0.0"
     cozy-ui-plus: "npm:^12.3.12"
-    cozy-viewer: "npm:^30.0.19"
+    cozy-viewer: "npm:^30.0.38"
     css-mediaquery: "npm:0.1.2"
     date-fns: "npm:2.30.0"
     diacritics: "npm:1.3.0"
@@ -12199,9 +12199,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-viewer@npm:^30.0.19":
-  version: 30.0.19
-  resolution: "cozy-viewer@npm:30.0.19"
+"cozy-viewer@npm:^30.0.38":
+  version: 30.0.38
+  resolution: "cozy-viewer@npm:30.0.38"
   dependencies:
     classnames: "npm:^2.5.1"
     hammerjs: "npm:^2.0.8"
@@ -12213,7 +12213,6 @@ __metadata:
     cozy-client: ">=57.0.0"
     cozy-device-helper: ">=2.0.0"
     cozy-flags: ">=4.8.1"
-    cozy-harvest-lib: ">=32.2.12"
     cozy-intent: ">=2.30.0"
     cozy-logger: ">=1.17.0"
     cozy-sharing: ">=30.0.0"
@@ -12223,7 +12222,7 @@ __metadata:
     react-dom: ">=16.12.0"
     react-router-dom: ">=6.14.2"
     twake-i18n: ">=0.3.0"
-  checksum: 10/ad892e9a9b56c468f860046fa7a7e7eafdc25299ea4b7766b1fcd76fd426c0ddfcd39a9a1daa01df1080e6c901531aea13583064a9a9c980d0380e2f6b445e8f
+  checksum: 10/e1d90614c64b4b25ba0655825c966219f945eb73f858cc40024a090be12534ff3a7fc7213eb6b16915a2b032ed29fc874746cb982de7a5202723cbb24c67783d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11710,7 +11710,7 @@ __metadata:
     cozy-pouch-link: "npm:^60.29.0"
     cozy-realtime: "npm:^5.9.3"
     cozy-search: "npm:^2.2.18"
-    cozy-sharing: "npm:^37.5.2"
+    cozy-sharing: "npm:^37.5.4"
     cozy-stack-client: "npm:^60.28.0"
     cozy-tsconfig: "npm:^1.8.1"
     cozy-ui: "npm:^141.0.0"
@@ -12060,9 +12060,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cozy-sharing@npm:^37.5.2":
-  version: 37.5.2
-  resolution: "cozy-sharing@npm:37.5.2"
+"cozy-sharing@npm:^37.5.4":
+  version: 37.5.4
+  resolution: "cozy-sharing@npm:37.5.4"
   dependencies:
     "@cozy/minilog": "npm:^1.0.0"
     classnames: "npm:^2.5.1"
@@ -12085,7 +12085,7 @@ __metadata:
     react: ">=16.12.0"
     react-router: ">=5.0.1"
     twake-i18n: ">=0.3.0"
-  checksum: 10/311cfb7c744417a13ac69604ec665bcc04511bbf3ef83d508f8ce32b1b4ecd9745cdf0b06a001340f8b50a971e3fd36b747b6359e6689e51e99a31bea800950e
+  checksum: 10/26b3027b890230e85ff4ec4cf0b901315211a9438d6921d2b9d2136e95eb7dcb19ba18db13342688e21f7a829ed6d437ea4eb29a1203474fe10b0b2177c5ae1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrade `cozy-viewer` from 30.0.19 to 30.0.38.
- Upgrade `cozy-sharing` from 37.5.2 to 37.5.4.

Both bumps pull in icon rendering fixes. The icons were passed as sprite name strings (`top`, `bottom`, `dash`, `plus`, `cloud`, `sync-cozy`, `to-the-cloud`) while `@linagora/twake-icons` expects components, and through an `icon` prop that `cozy-ui` `Buttons` does not support. Nothing rendered.

What comes back:

- PDF viewer toolbar: previous page, next page, zoom out and zoom in.
- Public sharing banner buttons: add to mine, sync to mine, and create a cozy. Visible in `PublicFolderView` and `LightFileViewer`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated underlying sharing and document-viewing components to newer versions.
  * Includes the latest maintenance updates, compatibility improvements, and stability enhancements from these components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->