### PR TITLE
fix(layout): keep the browser menu on text fields and in the bar

### DIFF
--- a/src/modules/layout/Layout.jsx
+++ b/src/modules/layout/Layout.jsx
@@ -18,6 +18,7 @@ import DriveText from '@/components/Icons/DriveText'
 import ButtonClient from '@/components/pushClient/Button'
 import { ROOT_DIR_ID, TRASH_DIR_ID } from '@/constants/config'
 import { useDisplayedFolder } from '@/hooks'
+import { isEditableTarget } from '@/hooks/helpers'
 import useCurrentFolderId from '@/hooks/useCurrentFolderId'
 import useCurrentFolderWriteAccess from '@/hooks/useCurrentFolderWriteAccess'
 import { initFlags } from '@/lib/flags'
@@ -46,6 +47,14 @@ export const consumeCreateOnRoot = () => {
     return true
   }
   return false
+}
+
+// Text fields keep their paste entry, and so does the bar, which renders
+// outside the application node but is a React child of this layout.
+const handleContextMenu = ev => {
+  if (isEditableTarget(ev.target)) return
+  if (!ev.target.closest('[role="application"]')) return
+  ev.preventDefault()
 }
 
 const LayoutContent = () => {
@@ -80,7 +89,7 @@ const LayoutContent = () => {
   }
 
   return (
-    <LayoutUI onContextMenu={ev => ev.preventDefault()}>
+    <LayoutUI onContextMenu={handleContextMenu}>
       <NewItemHighlightProvider>
         <BarComponent
           searchOptions={{ enabled: !isMobile }}


### PR DESCRIPTION
## Context

Right clicking the search field in the top bar, or the input in the sharing modal, gave no browser menu, so there was no way to paste.

The layout cancels the context menu so the file list can show its own, which caught every text field and the bar with it.

## Solution

Leave the event alone on text fields, and outside the application node.

Closes #4156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context menus now remain available for editable fields and content outside the application area.
  * Context menus are prevented only within designated application content where appropriate.
  * Upload actions now correctly respect the current drive and folder context, including read-only access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->