### PR TITLE
fix(selection): scope drag select to the file list

### DIFF
--- a/src/modules/selection/RectangularSelection.jsx
+++ b/src/modules/selection/RectangularSelection.jsx
@@ -386,7 +386,14 @@ const RectangularSelection = ({
           className={styles['cozy-selecto-box']}
           // eslint-disable-next-line react-hooks/refs
           container={containerRef.current}
-          dragContainer={window}
+          // The main column, so a drag can still start in the empty space
+          // above the files, which the grid view leaves almost none of inside
+          // the list. On window, a drag starting anywhere at all rubber band
+          // selected the files, including from behind a modal.
+          dragContainer={
+            // eslint-disable-next-line react-hooks/refs
+            containerRef.current.closest('main') ?? containerRef.current
+          }
           selectableTargets={['[data-file-id]']}
           selectByClick={false}
           selectFromInside={false}


### PR DESCRIPTION
## Context

Dragging anywhere on the page rubber band selected files, even from a modal backdrop, so files behind a modal could be selected and acted on.

Selecto was given `dragContainer={window}`, so it listened on the whole page and resolved the selection geometrically against the rows, whatever was drawn over them.

## Solution

Listen on the file list container instead, so a drag that starts outside it never begins a selection.

Closes #4158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted drag-to-select behavior to the file list area.
  * Prevented unintended rubber-band selections when dragging elsewhere on the page, including behind open dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->