### PR TITLE
feat: declare the io.cozy.banners permission

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -149,6 +149,14 @@
     }
   },
   "permissions": {
+    "banners": {
+      "description": "Required by the cozy-bar to display platform messages",
+      "type": "io.cozy.banners",
+      "verbs": [
+        "GET",
+        "PUT"
+      ]
+    },
     "files": {
       "description": "Required to access the files",
       "type": "io.cozy.files",


### PR DESCRIPTION
## Context

The bar renders platform messages inside the application. It reads them from the application's own context, so without the doctype declared the read is refused and nothing is displayed.

## Solution

Declare `io.cozy.banners`. `GET` to read, `PUT` because dismissing a banner writes `dismissedAt`, the only field a client ever writes.

No application code changes: the bar renders them.

Closes #1591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying platform messages through the cozy-bar.
  * Enabled retrieving and updating banner information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->