### PR TITLE
fix(migration): mount the Nextcloud migration banner only when its flag is on

### DIFF
--- a/src/modules/layout/Main.jsx
+++ b/src/modules/layout/Main.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { RealTimeQueries } from 'cozy-client'
+import flag from 'cozy-flags'
 import { Main as MainUI } from 'cozy-ui/transpiled/react/Layout'
 
 import { MigrationProgressBanner } from '@/components/Migration/MigrationProgressBanner'
@@ -13,8 +14,12 @@ const Main = ({ children, isPublic = false }) => (
     {!isPublic && (
       <>
         <PushBanner />
-        <RealTimeQueries doctype={NEXTCLOUD_MIGRATIONS_DOCTYPE} />
-        <MigrationProgressBanner />
+        {flag('settings.migration.enabled') && (
+          <>
+            <RealTimeQueries doctype={NEXTCLOUD_MIGRATIONS_DOCTYPE} />
+            <MigrationProgressBanner />
+          </>
+        )}
       </>
     )}
     {children}

--- a/src/modules/layout/Main.spec.jsx
+++ b/src/modules/layout/Main.spec.jsx
@@ -1,20 +1,29 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
+import flag from 'cozy-flags'
+
 import Main from './Main'
 
 jest.mock('cozy-ui/transpiled/react/Layout', () => ({
   Main: ({ children }) => <div>{children}</div>
 }))
-jest.mock('cozy-client', () => ({ RealTimeQueries: () => null }))
+jest.mock('cozy-client', () => ({
+  RealTimeQueries: () => <div data-testid="realtime-queries" />
+}))
+jest.mock('cozy-flags', () => jest.fn())
 jest.mock('@/components/PushBanner', () => () => (
   <div data-testid="push-banner" />
 ))
 jest.mock('@/components/Migration/MigrationProgressBanner', () => ({
-  MigrationProgressBanner: () => null
+  MigrationProgressBanner: () => <div data-testid="migration-banner" />
 }))
 
 describe('Main', () => {
+  beforeEach(() => {
+    flag.mockReturnValue(true)
+  })
+
   it('does not mount PushBanner on the public route', () => {
     // PushBanner calls useInstanceInfo, which queries /settings/disk-usage. A
     // public-share token cannot read it (403), and cozy-client's useQuery does
@@ -29,5 +38,21 @@ describe('Main', () => {
     render(<Main isPublic={false}>{[]}</Main>)
 
     expect(screen.queryByTestId('push-banner')).not.toBeNull()
+  })
+
+  it('does not mount the migration banner when the flag is off', () => {
+    flag.mockReturnValue(false)
+
+    render(<Main isPublic={false}>{[]}</Main>)
+
+    expect(screen.queryByTestId('migration-banner')).toBeNull()
+    expect(screen.queryByTestId('realtime-queries')).toBeNull()
+  })
+
+  it('mounts the migration banner when the flag is on', () => {
+    render(<Main isPublic={false}>{[]}</Main>)
+
+    expect(screen.queryByTestId('migration-banner')).not.toBeNull()
+    expect(screen.queryByTestId('realtime-queries')).not.toBeNull()
   })
 })


### PR DESCRIPTION
## Context

Every authenticated page mounted `<RealTimeQueries doctype="io.cozy.nextcloud.migrations" />` and `<MigrationProgressBanner />`, unconditionally. That means, on every instance, a websocket subscription on the doctype plus the banner's `_find` (with its `indexFields`, so index creation too) on the running migration.

On instances where the Nextcloud migration is not deployed, those calls and that subscription are pure noise: there is never a migration document to find, and no way to start one.

## Solution

Reuse `settings.migration.enabled`, the flag that already gates the migration route and its sidebar entry in cozy-settings, rather than introducing a Drive-specific one: one instance-level flag drives the whole feature.

Opt-in semantics, same as in settings — flag absent means no call at all. On instances where the migration is deployed, the flag must be set, otherwise the progress banner disappears (the transfer itself keeps running stack-side, only the display is gated).

A companion PR does the same in cozy-settings, where the banner and the realtime subscription escaped the flag too: linagora/cozy-settings#852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Migration progress information and real-time query updates are now displayed only when the migration feature is enabled.
  - Prevents migration-related interface elements from appearing in views where migration functionality is unavailable.

- **Tests**
  - Added coverage to verify that migration-related elements appear when enabled and remain hidden when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->