### PR TITLE
feat(recents): Support dataproxy in file picker and add E2E tests for recents

### DIFF
--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -71,7 +71,9 @@ const FEATURE_FLAGS = {
   'drive.shared-drive.enabled': true,
   'drive.federated-shared-folder.enabled': true,
   'drive.federated-shared-modal.enabled': true,
-  'drive.file-picker-demo.enabled': true
+  'drive.file-picker-demo.enabled': true,
+  'cozy.search.enabled': true,
+  'dataproxy.force-trusted-device.enabled': true
 }
 
 async function waitForStack(url: string, timeoutMs = 60_000): Promise<void> {
@@ -151,11 +153,11 @@ async function getSessionCookie(
   return { name: m[1], value: m[2] }
 }
 
-function isDriveInstalled(user: User): boolean {
+function isAppInstalled(user: User, slug: string): boolean {
   const apps = stackExec('apps', 'ls', '--domain', user.instance)
   return apps
     .split('\n')
-    .some(line => line.trim().split(/\s+/, 1)[0] === 'drive')
+    .some(line => line.trim().split(/\s+/, 1)[0] === slug)
 }
 
 async function setupUser(
@@ -164,7 +166,7 @@ async function setupUser(
   console.log(`[e2e] Ensuring instance for ${user.label} (${user.instance})...`)
   await createInstance(user)
 
-  if (isDriveInstalled(user)) {
+  if (isAppInstalled(user, 'drive')) {
     console.log(`[e2e] Reusing Drive app for ${user.label}.`)
   } else {
     console.log(`[e2e] Installing Drive app for ${user.label}...`)
@@ -173,6 +175,20 @@ async function setupUser(
       'install',
       'drive',
       'file:///app/drive',
+      '--domain',
+      user.instance
+    )
+  }
+
+  if (isAppInstalled(user, 'dataproxy')) {
+    console.log(`[e2e] Reusing Dataproxy app for ${user.label}.`)
+  } else {
+    console.log(`[e2e] Installing Dataproxy app for ${user.label}...`)
+    stackExec(
+      'apps',
+      'install',
+      'dataproxy',
+      'registry://dataproxy/stable',
       '--domain',
       user.instance
     )
@@ -224,13 +240,13 @@ async function createContact(hostUser: User, peer: User): Promise<void> {
 
 async function syncContacts(): Promise<void> {
   const entries = Object.values(USERS)
-  await Promise.all(
-    entries.flatMap(host =>
-      entries
-        .filter(peer => peer.instance !== host.instance)
-        .map(peer => createContact(host, peer))
-    )
-  )
+  for (const host of entries) {
+    for (const peer of entries) {
+      if (peer.instance !== host.instance) {
+        await createContact(host, peer)
+      }
+    }
+  }
 }
 
 export default async function globalSetup(): Promise<void> {
@@ -242,9 +258,7 @@ export default async function globalSetup(): Promise<void> {
     )
     compose('down', '--volumes')
   } else {
-    console.log(
-      '[e2e] Persistent mode — retaining this runtime and its data.'
-    )
+    console.log('[e2e] Persistent mode — retaining this runtime and its data.')
   }
 
   console.log('[e2e] Starting Docker containers...')
@@ -253,12 +267,13 @@ export default async function globalSetup(): Promise<void> {
   console.log('[e2e] Waiting for cozy-stack...')
   await waitForStack(STACK_URL)
 
-  const results = await Promise.all(
-    Object.values(USERS).map(async user => {
-      const cookie = await setupUser(user)
-      return [user.label, { domain: user.instance, ...cookie }] as const
-    })
-  )
+  const results: Array<
+    [string, { domain: string; cookieName: string; cookieValue: string }]
+  > = []
+  for (const user of Object.values(USERS)) {
+    const cookie = await setupUser(user)
+    results.push([user.label, { domain: user.instance, ...cookie }])
+  }
   saveAuthState(Object.fromEntries(results))
 
   console.log('[e2e] Cross-populating org contacts...')

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -160,38 +160,41 @@ function isAppInstalled(user: User, slug: string): boolean {
     .some(line => line.trim().split(/\s+/, 1)[0] === slug)
 }
 
+interface AppSpec {
+  slug: string
+  source: string
+  label: string
+}
+
+const DEFAULT_APPS: AppSpec[] = [
+  { slug: 'drive', source: 'file:///app/drive', label: 'Drive' },
+  {
+    slug: 'dataproxy',
+    source: 'registry://dataproxy/stable',
+    label: 'Dataproxy'
+  }
+]
+
 async function setupUser(
   user: User
 ): Promise<{ cookieName: string; cookieValue: string }> {
   console.log(`[e2e] Ensuring instance for ${user.label} (${user.instance})...`)
   await createInstance(user)
 
-  if (isAppInstalled(user, 'drive')) {
-    console.log(`[e2e] Reusing Drive app for ${user.label}.`)
-  } else {
-    console.log(`[e2e] Installing Drive app for ${user.label}...`)
-    stackExec(
-      'apps',
-      'install',
-      'drive',
-      'file:///app/drive',
-      '--domain',
-      user.instance
-    )
-  }
-
-  if (isAppInstalled(user, 'dataproxy')) {
-    console.log(`[e2e] Reusing Dataproxy app for ${user.label}.`)
-  } else {
-    console.log(`[e2e] Installing Dataproxy app for ${user.label}...`)
-    stackExec(
-      'apps',
-      'install',
-      'dataproxy',
-      'registry://dataproxy/stable',
-      '--domain',
-      user.instance
-    )
+  for (const app of DEFAULT_APPS) {
+    if (isAppInstalled(user, app.slug)) {
+      console.log(`[e2e] Reusing ${app.label} app for ${user.label}.`)
+    } else {
+      console.log(`[e2e] Installing ${app.label} app for ${user.label}...`)
+      stackExec(
+        'apps',
+        'install',
+        app.slug,
+        app.source,
+        '--domain',
+        user.instance
+      )
+    }
   }
 
   console.log(`[e2e] Setting feature flags for ${user.label}...`)

--- a/e2e/tests/file-picker-sharings.spec.ts
+++ b/e2e/tests/file-picker-sharings.spec.ts
@@ -166,4 +166,44 @@ test.describe.serial('File Picker Sharings', () => {
 
     await picker.closeConfirmation()
   })
+
+  test('displays a federated shared folder file in Recents via dataproxy and generates a download link', async ({
+    bobPage
+  }) => {
+    const picker = new FilePickerPage(bobPage, USERS.bob)
+    await picker.open()
+
+    const frame = bobPage.frameLocator('iframe[src*="intents"]')
+    const row = (name: string): Locator =>
+      frame
+        .getByTestId('list-item')
+        .filter({ has: frame.getByTitle(name, { exact: true }) })
+    const recentsTab = frame.getByRole('tab', { name: /Recents/i })
+    const downloadLinkButton = frame.getByTestId('temporary-download-link-btn')
+
+    await recentsTab.click()
+    await expect(recentsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(row(fileName)).toBeVisible({ timeout: 25_000 })
+
+    await row(fileName).getByTestId('choice-onclick').click()
+    await expect(downloadLinkButton).toBeEnabled()
+
+    await picker.clickTemporaryDownloadLink()
+    await picker.waitForClosed()
+
+    const link = await picker.getConfirmationLink()
+    expect(link).toMatch(/^https?:\/\//)
+
+    const document = await picker.getResultDocument()
+    expect(Array.isArray(document)).toBe(true)
+    const [entry] = document as Array<Record<string, unknown>>
+    expect(entry.name).toBe(fileName)
+    expect(entry.downloadLink).toBe(link)
+    expect(entry.sharingLink).toBeUndefined()
+
+    const response = await bobPage.request.get(link)
+    expect(response.status()).toBeLessThan(400)
+
+    await picker.closeConfirmation()
+  })
 })

--- a/e2e/tests/z-shared-drive-recents.spec.ts
+++ b/e2e/tests/z-shared-drive-recents.spec.ts
@@ -1,0 +1,74 @@
+import { copyFile } from 'fs/promises'
+import path from 'path'
+
+import { USERS } from '../helpers/config'
+import {
+  test,
+  expect,
+  stamp,
+  safeUnlink,
+  escapeRegExp
+} from '../helpers/fixtures'
+import {
+  createAndShareFolderWithBob,
+  openSharedDrive
+} from '../helpers/sharing'
+import { FileViewerPage } from '../pages/FileViewerPage'
+import { SidebarPage } from '../pages/SidebarPage'
+
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures')
+const SAMPLE = path.join(FIXTURE_DIR, 'sample.txt')
+
+const DRIVE_PREFIX = 'RecentDrive'
+const DRIVE_NAME = `${DRIVE_PREFIX}-${stamp()}`
+const SHARED_FILE_NAME = `recent-shared-${stamp()}.txt`
+test.describe.serial('Shared drive files in Recents (recipient)', () => {
+  test('Alice shares a folder containing a file with Bob', async ({
+    alicePage,
+    aliceDrive
+  }) => {
+    const filePath = path.join(FIXTURE_DIR, SHARED_FILE_NAME)
+    await copyFile(SAMPLE, filePath)
+    try {
+      await createAndShareFolderWithBob(alicePage, aliceDrive, DRIVE_NAME, {
+        seed: async () => {
+          await aliceDrive.uploadFiles(filePath)
+          await aliceDrive.row(SHARED_FILE_NAME).waitVisible()
+        }
+      })
+    } finally {
+      await safeUnlink(filePath)
+    }
+  })
+
+  test('Bob sees the federated shared file in Recents via dataproxy and can open it', async ({
+    bobPage,
+    bobDrive
+  }) => {
+    await openSharedDrive(bobPage, USERS.bob, bobDrive, DRIVE_NAME)
+    await bobDrive.row(SHARED_FILE_NAME).waitVisible({ timeout: 10_000 })
+
+    const sidebar = new SidebarPage(bobPage)
+    await sidebar.goToRecent()
+    await bobPage.waitForURL(/\/recent/)
+
+    await bobDrive.row(SHARED_FILE_NAME).waitVisible({ timeout: 25_000 })
+
+    const viewer = new FileViewerPage(bobPage)
+    const [proxiedDownload] = await Promise.all([
+      bobPage.waitForResponse(
+        res => /\/sharings\/drives\/[^/]+\/downloads/.test(res.url()),
+        { timeout: 20_000 }
+      ),
+      bobDrive.row(SHARED_FILE_NAME).open()
+    ])
+    expect(proxiedDownload.ok()).toBeTruthy()
+
+    await viewer.waitForOpen()
+    await bobPage.waitForURL(/\/shareddrive\/[^/]+\/[^/]+\/file\/[^/]+/)
+    await expect(bobPage).toHaveTitle(
+      new RegExp(escapeRegExp(SHARED_FILE_NAME)),
+      { timeout: 15_000 }
+    )
+  })
+})

--- a/src/lib/IntentProvider.jsx
+++ b/src/lib/IntentProvider.jsx
@@ -2,16 +2,25 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import { CozyProvider } from 'cozy-client'
+import { DataProxyProvider } from 'cozy-dataproxy-lib'
 import SharingProvider from 'cozy-sharing'
 import { I18n } from 'twake-i18n'
+
+import { DOCTYPE_APPS, DOCTYPE_CONTACTS, DOCTYPE_FILES } from '@/lib/doctypes'
 
 const IntentProvider = ({ client, lang, polyglot, dictRequire, children }) => {
   return (
     <I18n lang={lang} polyglot={polyglot} dictRequire={dictRequire}>
       <CozyProvider client={client}>
-        <SharingProvider doctype="io.cozy.files" documentType="Files">
-          {children}
-        </SharingProvider>
+        <DataProxyProvider
+          options={{
+            doctypes: [DOCTYPE_FILES, DOCTYPE_CONTACTS, DOCTYPE_APPS]
+          }}
+        >
+          <SharingProvider doctype="io.cozy.files" documentType="Files">
+            {children}
+          </SharingProvider>
+        </DataProxyProvider>
       </CozyProvider>
     </I18n>
   )

--- a/src/modules/services/components/Picker.recents.spec.jsx
+++ b/src/modules/services/components/Picker.recents.spec.jsx
@@ -2,14 +2,16 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import { Q, createMockClient } from 'cozy-client'
+import { useDataProxy } from 'cozy-dataproxy-lib'
 
 import { buildContentFolderQuery } from './FilePicker/queries'
 import Picker from './Picker'
 import AppLike from 'test/components/AppLike'
 
-import useRecentFiles from '@/hooks/useRecentFiles'
-
-jest.mock('@/hooks/useRecentFiles')
+jest.mock('cozy-dataproxy-lib', () => ({
+  DataProxyProvider: ({ children }) => children,
+  useDataProxy: jest.fn()
+}))
 
 jest.mock('cozy-ui/transpiled/react/Table/Virtualized', () => {
   const React = require('react')
@@ -57,16 +59,6 @@ jest.mock('cozy-ui/transpiled/react/Table/Virtualized', () => {
   return { __esModule: true, default: VirtualizedTable }
 })
 
-let recentResult
-let recentsMountCount
-
-function useRecentFilesMock() {
-  React.useEffect(() => {
-    recentsMountCount += 1
-  }, [])
-  return recentResult
-}
-
 const rootId = 'io.cozy.files.root-dir'
 const recentFile = {
   _id: 'recent-shared-id',
@@ -110,15 +102,13 @@ function makeClient() {
 describe('Picker Recents integration', () => {
   afterEach(() => jest.clearAllMocks())
 
-  it('revalidates a selected recent drive item through its shared drive', async () => {
+  it('fetches federated shared folder files from dataproxy and revalidates on pick', async () => {
     window.innerWidth = 1024
-    recentsMountCount = 0
-    recentResult = {
-      data: [recentFile],
-      fetchStatus: 'loaded',
-      error: null
-    }
-    useRecentFiles.mockImplementation(useRecentFilesMock)
+    const mockRecents = jest.fn().mockResolvedValue([recentFile])
+    useDataProxy.mockReturnValue({
+      dataProxyServicesAvailable: true,
+      recents: mockRecents
+    })
     const client = makeClient()
     const service = {
       cancel: jest.fn(),
@@ -137,12 +127,12 @@ describe('Picker Recents integration', () => {
       'data-file-id',
       recentFile._id
     )
-    await waitFor(() => expect(recentsMountCount).toBe(1))
+    await waitFor(() => expect(mockRecents).toHaveBeenCalledTimes(1))
 
     fireEvent.click(screen.getByRole('tab', { name: /My Drive/i }))
     fireEvent.click(screen.getByRole('tab', { name: /Recents/i }))
     const row = await screen.findByTestId('list-item')
-    await waitFor(() => expect(recentsMountCount).toBe(2))
+    await waitFor(() => expect(mockRecents).toHaveBeenCalledTimes(2))
 
     const query = jest.spyOn(client, 'query').mockResolvedValue({
       data: { ...recentFile }


### PR DESCRIPTION
- Wrap IntentProvider in DataProxyProvider with doctypes (files, contacts, apps)
- Update Picker.recents.spec.jsx to test integration with useDataProxy
- Install dataproxy app and configure flags in e2e/setup/global-setup.ts
- Add E2E test for federated shared folder files in File Picker Recents tab
- Add E2E test for federated shared folder files in Drive Recents view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Federated shared-folder files are now available in **Recents**.
  - Shared files can be selected through the file picker and used to generate temporary download links.
  - Files from shared drives can be opened from **Recents**, with downloads routed through the data proxy.
  - Recents refresh when switching between **Recents** and **My Drive**, ensuring newly available shared files are displayed.
  - Shared files can be viewed successfully after opening them from Recents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->