### PR TITLE
test: Execute nested sharing test for 3 different flags

### DIFF
--- a/e2e/helpers/flags.ts
+++ b/e2e/helpers/flags.ts
@@ -1,5 +1,18 @@
 import { stackExec } from './config'
 
+/** Flags applied to every instance at provisioning time (global-setup).
+ * Specs overriding flags via setFlags should spread over this map so each
+ * call re-asserts a full, deterministic state. */
+export const DEFAULT_FLAGS: Record<string, boolean | string | number> = {
+  'cozy.hide-sharing-cozy-to-cozy': true,
+  'drive.shared-drive.enabled': true,
+  'drive.federated-shared-folder.enabled': true,
+  'drive.federated-shared-modal.enabled': true,
+  'drive.file-picker-demo.enabled': true,
+  'cozy.search.enabled': true,
+  'dataproxy.force-trusted-device.enabled': true
+}
+
 export function setFlags(
   instance: string,
   flags: Record<string, boolean | string | number>

--- a/e2e/helpers/stack.ts
+++ b/e2e/helpers/stack.ts
@@ -168,6 +168,40 @@ export async function overwriteFile({
   }
 }
 
+/** Trash a root-level file or folder by name. Trashing a shared folder
+ * revokes its members, so cross-instance test fixtures can clean up their
+ * sharings here. No-op when the name does not exist. */
+export async function trashByName(
+  instance: string,
+  name: string
+): Promise<void> {
+  const listRes = await fetch(`http://${instance}/files/${ROOT_DIR_ID}`, {
+    headers: {
+      Authorization: `Bearer ${filesToken(instance)}`,
+      Accept: 'application/json'
+    }
+  })
+  if (!listRes.ok) {
+    throw new Error(
+      `List root files on ${instance} failed (${listRes.status}): ${await listRes.text()}`
+    )
+  }
+  const body = (await listRes.json()) as {
+    included?: { id: string; attributes?: { name?: string } }[]
+  }
+  const doc = (body.included ?? []).find(item => item.attributes?.name === name)
+  if (!doc) return
+  const delRes = await fetch(`http://${instance}/files/${doc.id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${filesToken(instance)}` }
+  })
+  if (!delRes.ok) {
+    throw new Error(
+      `Trash ${name} (${doc.id}) on ${instance} failed (${delRes.status}): ${await delRes.text()}`
+    )
+  }
+}
+
 /** Number of versions the stack currently keeps for a file. */
 export async function countFileVersions({
   instance,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -19,8 +19,9 @@ export default defineConfig({
   // 60s on a slow stack; give per-test headroom.
   timeout: 120_000,
   // Covers docker provisioning plus the full suite — the shared-drive specs
-  // add ~15 multi-instance tests on a single worker.
-  globalTimeout: 900_000,
+  // add ~15 multi-instance tests and the nested-sharing spec runs its five
+  // scenarios for every flag combination, on a single worker.
+  globalTimeout: 1_500_000,
   projects: [
     {
       name: 'chromium',

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -16,7 +16,7 @@ import {
   User,
   stackExec
 } from '../helpers/config'
-import { setFlags } from '../helpers/flags'
+import { DEFAULT_FLAGS, setFlags } from '../helpers/flags'
 
 const ADMIN_AUTH = `Basic ${Buffer.from(`${ADMIN_USER}:${ADMIN_PASSPHRASE}`).toString('base64')}`
 
@@ -64,16 +64,6 @@ async function createInstance(user: User): Promise<void> {
       `Failed to create instance ${user.instance} (${res.status}): ${body}`
     )
   }
-}
-
-const FEATURE_FLAGS = {
-  'cozy.hide-sharing-cozy-to-cozy': true,
-  'drive.shared-drive.enabled': true,
-  'drive.federated-shared-folder.enabled': true,
-  'drive.federated-shared-modal.enabled': true,
-  'drive.file-picker-demo.enabled': true,
-  'cozy.search.enabled': true,
-  'dataproxy.force-trusted-device.enabled': true
 }
 
 async function waitForStack(url: string, timeoutMs = 60_000): Promise<void> {
@@ -198,7 +188,7 @@ async function setupUser(
   }
 
   console.log(`[e2e] Setting feature flags for ${user.label}...`)
-  setFlags(user.instance, FEATURE_FLAGS)
+  setFlags(user.instance, DEFAULT_FLAGS)
 
   console.log(`[e2e] Getting session cookie for ${user.label}...`)
   const cookie = await getSessionCookie(user)

--- a/e2e/tests/file-picker.mobile.spec.ts
+++ b/e2e/tests/file-picker.mobile.spec.ts
@@ -142,6 +142,10 @@ test.describe.serial('File Picker Sharings mobile', () => {
     await expect(row(rootName)).toBeVisible()
 
     await picker.tapItem(rootName)
-    await expect(row(nestedName)).toBeVisible()
+    // Virtualized list + proxied listing: poll instead of a bare 5s expect.
+    await expect(async () => {
+      await picker.scrollToItem(nestedName)
+      await expect(row(nestedName)).toBeVisible()
+    }).toPass({ timeout: 30_000 })
   })
 })

--- a/e2e/tests/z-nested-sharing.spec.ts
+++ b/e2e/tests/z-nested-sharing.spec.ts
@@ -1,186 +1,296 @@
 import { USERS } from '../helpers/config'
 import { test, expect, stamp } from '../helpers/fixtures'
+import { DEFAULT_FLAGS, setFlags } from '../helpers/flags'
+import { trashByName } from '../helpers/stack'
 import { ShareModalPage } from '../pages/ShareModalPage'
 
-const PARENTFOLDER = `Nested Parent ${stamp()}`
-const SUBFOLDER = `Nested Child ${stamp()}`
+interface FlagCombo {
+  federated: boolean
+  hide: boolean
+  sharedDrive: boolean
+}
 
-// Modal surfaces with the default FEATURE_FLAGS (federated on): sharing a
-// folder creates a shared drive, and the share modal of a folder inside a
-// shared one shows the only-by-link banner instead of the contact input and
-// the Done button, while keeping the parent's members listed and manageable.
-test.describe.serial('Nested sharing — share modal surfaces', () => {
-  test('parent modal before sharing', async ({ alicePage, aliceDrive }) => {
-    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
-    await aliceDrive.createFolder(PARENTFOLDER)
-    await aliceDrive.openFolder(PARENTFOLDER)
+const COMBOS: FlagCombo[] = []
+for (const federated of [true, false]) {
+  for (const hide of [true, false]) {
+    for (const sharedDrive of [true, false]) {
+      COMBOS.push({ federated, hide, sharedDrive })
+    }
+  }
+}
 
-    await aliceDrive.createFolder(SUBFOLDER)
+const comboLabel = (combo: FlagCombo): string =>
+  `federated=${combo.federated} hide-cozy-to-cozy=${combo.hide} shared-drive=${combo.sharedDrive}`
 
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const modal = new ShareModalPage(alicePage)
-    await modal.waitForOpen()
-
-    // Not shared and no shared child: the classic modal.
-    await expect(
-      modal.dialog.getByText(/can only be shared by link/i)
-    ).toHaveCount(0)
-    await expect(modal.dialog.getByRole('combobox')).toBeVisible()
-    await expect(modal.dialog.getByRole('listitem').first()).toBeVisible()
-    await expect(
-      modal.dialog.getByRole('button', { name: /^copy link$/i })
-    ).toBeVisible()
-    await expect(
-      modal.dialog.getByRole('button', { name: /^done$/i })
-    ).toBeVisible()
-
-    await modal.addMember(USERS.bob.email)
-    await modal.share()
-  })
-
-  test('parent modal after sharing shows members with permission menu', async ({
-    alicePage,
-    aliceDrive
-  }) => {
-    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
-    await aliceDrive.openFolder(PARENTFOLDER)
-
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const modal = new ShareModalPage(alicePage)
-    await modal.waitForOpen()
-
-    // Auto-accept is on in the e2e stack, so Bob is a confirmed member and
-    // carries the per-member role menu.
-    await expect(modal.memberItem('bob')).toBeVisible()
-    await expect(modal.memberRole('bob')).toHaveText(/editor/i)
-
-    await modal.close()
-  })
-
-  test('child modal of a shared folder', async ({ alicePage, aliceDrive }) => {
-    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
-    await aliceDrive.openFolder(PARENTFOLDER)
-    await aliceDrive.openFolder(SUBFOLDER)
-
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const modal = new ShareModalPage(alicePage)
-    await modal.waitForOpen()
-
-    await expect(
-      modal.dialog.getByText(/can only be shared by link/i)
-    ).toBeVisible()
-    await expect(modal.dialog.getByRole('combobox')).toHaveCount(0)
-    await expect(modal.memberItem('bob')).toBeVisible()
-    await expect(modal.memberRole('bob')).toHaveText(/editor/i)
-    await expect(
-      modal.dialog.getByRole('button', { name: /^copy link$/i })
-    ).toBeVisible()
-    await expect(
-      modal.dialog.getByRole('button', { name: /^done$/i })
-    ).toHaveCount(0)
-
-    await modal.close()
-  })
+const comboFlags = (combo: FlagCombo): Record<string, boolean> => ({
+  'drive.federated-shared-folder.enabled': combo.federated,
+  'cozy.hide-sharing-cozy-to-cozy': combo.hide,
+  'drive.shared-drive.enabled': combo.sharedDrive
 })
 
-// Self-contained scenarios on a directly shared child, each with its own
-// fixtures — outside the serial chain above so a failure there can't skip
-// them.
-test.describe('Nested sharing — direct child sharing', () => {
-  test('child modal shared directly', async ({ alicePage, aliceDrive }) => {
-    const parent = `Nested Direct Parent ${stamp()}`
-    const child = `Nested Direct Child ${stamp()}`
+// The same modal surfaces are asserted for every flag combination. With
+// federated on, sharing a folder creates a shared drive and a folder inside
+// a shared one shows the only-by-link banner instead of the contact input,
+// while keeping the parent's members listed and manageable. With federated
+// off, the legacy modal keeps the same banner surfaces but lists direct
+// recipients only (shared-drive itself never affects the modal).
+for (const combo of COMBOS) {
+  // federated=off + hide-cozy-to-cozy=on → the legacy modal renders
+  // ShareDialogOnlyByLink for every document: contact sharing is impossible,
+  // so the five scenarios cannot even set up. The smoke test pins the
+  // degenerate modal instead — re-register the scenarios if sharing becomes
+  // possible here again.
+  const canShareViaModal = combo.federated || !combo.hide
 
-    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
-    await aliceDrive.createFolder(parent)
-    await aliceDrive.openFolder(parent)
-    await aliceDrive.createFolder(child)
-    await aliceDrive.openFolder(child)
+  test.describe
+    .serial(`Nested sharing — share modal surfaces [${comboLabel(combo)}]`, () => {
+    // stamp() is monotonic: each combo's describe gets unique names. Declared
+    // before the hooks so the afterAll cleanup can trash them.
+    const PARENTFOLDER = `Nested Parent ${stamp()}`
+    const SUBFOLDER = `Nested Child ${stamp()}`
+    const DIRECT_PARENT = `Nested Direct Parent ${stamp()}`
+    const SHAREDCHILD_PARENT = `Nested Shared-Child Parent ${stamp()}`
 
-    // Before sharing: no shared parent, no shared child — classic modal.
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const modal = new ShareModalPage(alicePage)
-    await modal.waitForOpen()
+    test.beforeAll(() => {
+      setFlags(USERS.alice.instance, {
+        ...DEFAULT_FLAGS,
+        ...comboFlags(combo)
+      })
+    })
+    test.afterAll(async () => {
+      if (canShareViaModal) {
+        // Trash the combo's fixtures: each combo leaves shared folders on
+        // Alice's instance otherwise, and the accumulation slows down the
+        // later specs of the single-worker run. Trashing revokes Bob.
+        await trashByName(USERS.alice.instance, PARENTFOLDER)
+        await trashByName(USERS.alice.instance, DIRECT_PARENT)
+        await trashByName(USERS.alice.instance, SHAREDCHILD_PARENT)
+      }
+      setFlags(USERS.alice.instance, DEFAULT_FLAGS)
+    })
 
-    await expect(
-      modal.dialog.getByText(/can only be shared by link/i)
-    ).toHaveCount(0)
-    await expect(modal.dialog.getByRole('combobox')).toBeVisible()
-    await expect(modal.dialog.getByRole('listitem').first()).toBeVisible()
-    await expect(modal.memberItem('bob')).toHaveCount(0)
-    await expect(
-      modal.dialog.getByRole('button', { name: /^copy link$/i })
-    ).toBeVisible()
-    await expect(
-      modal.dialog.getByRole('button', { name: /^done$/i })
-    ).toBeVisible()
+    if (canShareViaModal) {
+      test('parent modal before sharing', async ({ alicePage, aliceDrive }) => {
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.createFolder(PARENTFOLDER)
+        await aliceDrive.openFolder(PARENTFOLDER)
 
-    await modal.addMember(USERS.bob.email)
-    await modal.share()
+        await aliceDrive.createFolder(SUBFOLDER)
 
-    // The child is now the root of its own shared drive: the modal stays
-    // classic and Bob is a confirmed member with a role menu.
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const sharedModal = new ShareModalPage(alicePage)
-    await sharedModal.waitForOpen()
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const modal = new ShareModalPage(alicePage)
+        await modal.waitForOpen()
 
-    await expect(
-      sharedModal.dialog.getByText(/can only be shared by link/i)
-    ).toHaveCount(0)
-    await expect(sharedModal.dialog.getByRole('combobox')).toBeVisible()
-    await expect(sharedModal.memberItem('bob')).toBeVisible()
-    await expect(sharedModal.memberRole('bob')).toHaveText(/editor/i)
-    await expect(
-      sharedModal.dialog.getByRole('button', { name: /^copy link$/i })
-    ).toBeVisible()
-    await expect(
-      sharedModal.dialog.getByRole('button', { name: /^done$/i })
-    ).toBeVisible()
+        // Not shared and no shared child: the classic modal.
+        await expect(
+          modal.dialog.getByText(/can only be shared by link/i)
+        ).toHaveCount(0)
+        await expect(modal.dialog.getByRole('combobox')).toBeVisible()
+        await expect(modal.dialog.getByRole('listitem').first()).toBeVisible()
+        await expect(
+          modal.dialog.getByRole('button', { name: /^copy link$/i })
+        ).toBeVisible()
+        await expect(
+          modal.dialog.getByRole('button', { name: /^done$/i })
+        ).toBeVisible()
 
-    await sharedModal.close()
+        await modal.addMember(USERS.bob.email)
+        await modal.share()
+      })
+
+      test('parent modal after sharing shows members with permission menu', async ({
+        alicePage,
+        aliceDrive
+      }) => {
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.openFolder(PARENTFOLDER)
+
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const modal = new ShareModalPage(alicePage)
+        await modal.waitForOpen()
+
+        // Auto-accept is on in the e2e stack, so Bob is a confirmed member
+        // and carries the per-member role menu.
+        await expect(modal.memberItem('bob')).toBeVisible()
+        await expect(modal.memberRole('bob')).toHaveText(/editor/i)
+
+        await modal.close()
+      })
+
+      test('child modal of a shared folder', async ({
+        alicePage,
+        aliceDrive
+      }) => {
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.openFolder(PARENTFOLDER)
+        await aliceDrive.openFolder(SUBFOLDER)
+
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const modal = new ShareModalPage(alicePage)
+        await modal.waitForOpen()
+
+        await expect(
+          modal.dialog.getByText(/can only be shared by link/i)
+        ).toBeVisible()
+        await expect(modal.dialog.getByRole('combobox')).toHaveCount(0)
+        await expect(
+          modal.dialog.getByRole('button', { name: /^copy link$/i })
+        ).toBeVisible()
+        if (combo.federated) {
+          // The federated modal resolves the parent sharing's members.
+          await expect(modal.memberItem('bob')).toBeVisible()
+          await expect(modal.memberRole('bob')).toHaveText(/editor/i)
+          await expect(
+            modal.dialog.getByRole('button', { name: /^done$/i })
+          ).toHaveCount(0)
+        } else {
+          // The legacy modal lists direct recipients only — the child
+          // inherits none — but its Done button is always rendered.
+          await expect(modal.memberItem('bob')).toHaveCount(0)
+          await expect(
+            modal.dialog.getByRole('button', { name: /^done$/i })
+          ).toBeVisible()
+        }
+
+        await modal.close()
+      })
+
+      test('child modal shared directly', async ({ alicePage, aliceDrive }) => {
+        const child = `Nested Direct Child ${stamp()}`
+
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.createFolder(DIRECT_PARENT)
+        await aliceDrive.openFolder(DIRECT_PARENT)
+        await aliceDrive.createFolder(child)
+        await aliceDrive.openFolder(child)
+
+        // Before sharing: no shared parent, no shared child — classic modal.
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const modal = new ShareModalPage(alicePage)
+        await modal.waitForOpen()
+
+        await expect(
+          modal.dialog.getByText(/can only be shared by link/i)
+        ).toHaveCount(0)
+        await expect(modal.dialog.getByRole('combobox')).toBeVisible()
+        await expect(modal.dialog.getByRole('listitem').first()).toBeVisible()
+        await expect(modal.memberItem('bob')).toHaveCount(0)
+        await expect(
+          modal.dialog.getByRole('button', { name: /^copy link$/i })
+        ).toBeVisible()
+        await expect(
+          modal.dialog.getByRole('button', { name: /^done$/i })
+        ).toBeVisible()
+
+        await modal.addMember(USERS.bob.email)
+        await modal.share()
+
+        // After sharing, the modal stays classic and Bob is a confirmed
+        // member with a role menu.
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const sharedModal = new ShareModalPage(alicePage)
+        await sharedModal.waitForOpen()
+
+        await expect(
+          sharedModal.dialog.getByText(/can only be shared by link/i)
+        ).toHaveCount(0)
+        await expect(sharedModal.dialog.getByRole('combobox')).toBeVisible()
+        await expect(sharedModal.memberItem('bob')).toBeVisible()
+        await expect(sharedModal.memberRole('bob')).toHaveText(/editor/i)
+        await expect(
+          sharedModal.dialog.getByRole('button', { name: /^copy link$/i })
+        ).toBeVisible()
+        await expect(
+          sharedModal.dialog.getByRole('button', { name: /^done$/i })
+        ).toBeVisible()
+
+        await sharedModal.close()
+      })
+
+      test('parent modal of a shared child', async ({
+        alicePage,
+        aliceDrive
+      }) => {
+        const child = `Nested Shared-Child Child ${stamp()}`
+
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.createFolder(SHAREDCHILD_PARENT)
+        await aliceDrive.openFolder(SHAREDCHILD_PARENT)
+        await aliceDrive.createFolder(child)
+        await aliceDrive.openFolder(child)
+
+        // Share the child directly.
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const modal = new ShareModalPage(alicePage)
+        await modal.waitForOpen()
+        await modal.addMember(USERS.bob.email)
+        await modal.share()
+
+        // The parent itself has no direct sharing: its modal is restricted
+        // by the shared child and lists none of the child's recipients.
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.openFolder(SHAREDCHILD_PARENT)
+
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const parentModal = new ShareModalPage(alicePage)
+        await parentModal.waitForOpen()
+
+        await expect(
+          parentModal.dialog.getByText(/can only be shared by link/i)
+        ).toBeVisible()
+        await expect(
+          parentModal.dialog.getByText(/it contains a shared element/i)
+        ).toBeVisible()
+        await expect(parentModal.dialog.getByRole('combobox')).toHaveCount(0)
+        await expect(parentModal.memberItem('bob')).toHaveCount(0)
+        await expect(
+          parentModal.dialog.getByRole('button', { name: /^copy link$/i })
+        ).toBeVisible()
+        if (combo.federated) {
+          await expect(
+            parentModal.dialog.getByRole('button', { name: /^done$/i })
+          ).toHaveCount(0)
+        } else {
+          // The legacy modal always renders its Done button.
+          await expect(
+            parentModal.dialog.getByRole('button', { name: /^done$/i })
+          ).toBeVisible()
+        }
+
+        await parentModal.close()
+      })
+    } else {
+      test('hide cozy-to-cozy forces only-by-link modal', async ({
+        alicePage,
+        aliceDrive
+      }) => {
+        const parent = `Nested Only-By-Link ${stamp()}`
+
+        await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
+        await aliceDrive.createFolder(parent)
+        await aliceDrive.openFolder(parent)
+
+        await alicePage.getByRole('button', { name: /share/i }).click()
+        const modal = new ShareModalPage(alicePage)
+        await modal.waitForOpen()
+
+        // No contact sharing at all: no banner text, no contact input,
+        // no Done — only the member list and the link affordance.
+        await expect(
+          modal.dialog.getByText(/can only be shared by link/i)
+        ).toHaveCount(0)
+        await expect(modal.dialog.getByRole('combobox')).toHaveCount(0)
+        await expect(
+          modal.dialog.getByRole('button', { name: /^done$/i })
+        ).toHaveCount(0)
+        await expect(modal.dialog.getByText(/who has access/i)).toBeVisible()
+        await expect(modal.dialog.getByRole('listitem').first()).toBeVisible()
+        await expect(
+          modal.dialog.getByRole('button', { name: /^copy link$/i })
+        ).toBeVisible()
+
+        await modal.close()
+      })
+    }
   })
-
-  test('parent modal of a shared child', async ({ alicePage, aliceDrive }) => {
-    const parent = `Nested Shared-Child Parent ${stamp()}`
-    const child = `Nested Shared-Child Child ${stamp()}`
-
-    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
-    await aliceDrive.createFolder(parent)
-    await aliceDrive.openFolder(parent)
-    await aliceDrive.createFolder(child)
-    await aliceDrive.openFolder(child)
-
-    // Share the child directly.
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const modal = new ShareModalPage(alicePage)
-    await modal.waitForOpen()
-    await modal.addMember(USERS.bob.email)
-    await modal.share()
-
-    // The parent itself has no direct sharing: its modal is restricted by
-    // the shared child and lists none of the child's recipients.
-    await alicePage.goto(`${USERS.alice.appUrl}/#/folder`)
-    await aliceDrive.openFolder(parent)
-
-    await alicePage.getByRole('button', { name: /share/i }).click()
-    const parentModal = new ShareModalPage(alicePage)
-    await parentModal.waitForOpen()
-
-    await expect(
-      parentModal.dialog.getByText(/can only be shared by link/i)
-    ).toBeVisible()
-    await expect(
-      parentModal.dialog.getByText(/it contains a shared element/i)
-    ).toBeVisible()
-    await expect(parentModal.dialog.getByRole('combobox')).toHaveCount(0)
-    await expect(parentModal.memberItem('bob')).toHaveCount(0)
-    await expect(
-      parentModal.dialog.getByRole('button', { name: /^copy link$/i })
-    ).toBeVisible()
-    await expect(
-      parentModal.dialog.getByRole('button', { name: /^done$/i })
-    ).toHaveCount(0)
-
-    await parentModal.close()
-  })
-})
+}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -235,6 +235,8 @@ declare module 'cozy-realtime' {
       doctype: string,
       callback: () => void | Promise<void>
     ) => void
+    on: (event: string, callback: () => void) => void
+    removeListener: (event: string, callback: () => void) => void
     stop: () => void
   }
 }

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.spec.jsx
@@ -12,6 +12,8 @@ import logger from '@/lib/logger'
 jest.mock('cozy-realtime', () => {
   return jest.fn().mockImplementation(() => ({
     subscribe: jest.fn(),
+    on: jest.fn(),
+    removeListener: jest.fn(),
     stop: jest.fn()
   }))
 })
@@ -226,6 +228,8 @@ describe('useSharedDriveFolder', () => {
         subscribe: jest.fn((_event, _doctype, callback) => {
           triggerRealtimeEvent = callback
         }),
+        on: jest.fn(),
+        removeListener: jest.fn(),
         stop: jest.fn()
       }))
     })

--- a/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
+++ b/src/modules/shareddrives/hooks/useSharedDriveFolder.tsx
@@ -149,10 +149,15 @@ const useSharedDriveFolder = ({
       realtime.subscribe('updated', 'io.cozy.files', debouncedFetch)
       realtime.subscribe('created', 'io.cozy.files', debouncedFetch)
       realtime.subscribe('deleted', 'io.cozy.files', debouncedFetch)
+      // Events fired while the socket is down or not yet subscribed are lost
+      // (the shared-drive realtime channel replays nothing): catch up with a
+      // background refetch on every (re)connect.
+      realtime.on('ready', debouncedFetch)
     }
 
     return (): void => {
       if (realtime) {
+        realtime.removeListener('ready', debouncedFetch)
         realtime.stop()
       }
       debouncedFetch.cancel()


### PR DESCRIPTION
We previously added some tests for nested sharing https://github.com/linagora/twake-drive/pull/4177 . But by default, the e2e are only executed in a specific flag context set in the config file.

Here we want to execute these tests by switching true/false for 3 different flags `drive.federated-shared-folder.enabled`, `cozy.hide-sharing-cozy-to-cozy`, `drive.shared-drive.enabled`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Shared-drive file changes made while disconnected or reconnecting are now detected after the connection is restored.
  - Improved reliability when loading nested items in the mobile file picker.

- **Tests**
  - Expanded end-to-end coverage for nested sharing across federation, sharing visibility, and shared-drive settings.
  - Added validation for recipient lists, modal behavior, unavailable contact sharing, and link-only sharing.
  - Improved test consistency with standardized feature flags and support for longer-running scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->