### PR TITLE
fix: Allow to open shortcuts as a shared drive recipients

### DIFF
--- a/src/modules/navigation/AppRoute.jsx
+++ b/src/modules/navigation/AppRoute.jsx
@@ -193,6 +193,7 @@ const getEditorRoutes = () => (
 const AppRoutes = ({ sharedDrivesEnabled }) => (
   <SentryRoutes>
     <Route path="external/:fileId" element={<ExternalRedirect />} />
+    <Route path="external/:driveId/:fileId" element={<ExternalRedirect />} />
     <Route path="note/:fileId" element={<PublicNoteRedirect />} />
     <Route path="note/:driveId/:fileId" element={<PublicNoteRedirect />} />
 

--- a/src/modules/navigation/ExternalRedirect.jsx
+++ b/src/modules/navigation/ExternalRedirect.jsx
@@ -10,9 +10,13 @@ import EmptyIcon from '@/assets/icons/icon-folder-broken.svg'
 import { DummyLayout } from '@/modules/layout/DummyLayout'
 
 const ExternalRedirect = ({ t }) => {
-  const { fileId } = useParams()
+  const { driveId, fileId } = useParams()
   const client = useClient()
-  const { shortcutInfos, fetchStatus } = useFetchShortcut(client, fileId)
+  const { shortcutInfos, fetchStatus } = useFetchShortcut(
+    client,
+    fileId,
+    driveId
+  )
   if (shortcutInfos) {
     // eslint-disable-next-line react-hooks/immutability
     window.location.href = shortcutInfos.data.attributes.url

--- a/src/modules/navigation/hooks/helpers.spec.js
+++ b/src/modules/navigation/hooks/helpers.spec.js
@@ -505,6 +505,13 @@ describe('computePath', () => {
     )
   })
 
+  it('should return correct path for a shortcut inside a shared drive', () => {
+    const file = { _id: 'shortcut123', driveId: 'drive123' }
+    expect(computePath(file, { type: 'shortcut', pathname: '/any' })).toBe(
+      '/external/drive123/shortcut123'
+    )
+  })
+
   it('should return correct path for directory at root', () => {
     const file = { _id: 'dir123' }
     expect(computePath(file, { type: 'directory', pathname: '/root' })).toBe(

--- a/src/modules/navigation/hooks/helpers.ts
+++ b/src/modules/navigation/hooks/helpers.ts
@@ -214,7 +214,9 @@ export const computePath = (
     case 'grist':
       return `/bridge/grist/${(file as IOCozyFile).metadata.externalId}`
     case 'shortcut':
-      return `/external/${file._id}`
+      return driveId
+        ? `/external/${driveId}/${file._id}`
+        : `/external/${file._id}`
     case 'directory':
       if (isOwner && pathname.startsWith('/sharings/')) {
         return `/folder/${file._id}`


### PR DESCRIPTION
Close https://github.com/linagora/twake-drive/issues/4183.

- [x] update cozy-client https://github.com/linagora/cozy-client/pull/1718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed shortcut navigation for files stored on shared drives.
  - Shared-drive shortcuts now open with the correct drive and file information.
  - Standard file shortcuts continue using the existing navigation behavior.
  - Improved external shortcut redirection for both standard files and shared-drive files.
  - Updated routing so shortcut links reliably open the intended file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->