### PR TITLE
fix: Avoid potentiel shortcut XSS

### DIFF
--- a/src/modules/navigation/ExternalRedirect.jsx
+++ b/src/modules/navigation/ExternalRedirect.jsx
@@ -9,18 +9,31 @@ import { translate } from 'twake-i18n'
 import EmptyIcon from '@/assets/icons/icon-folder-broken.svg'
 import { DummyLayout } from '@/modules/layout/DummyLayout'
 
+export const isNavigableUrl = url => {
+  try {
+    const { protocol } = new URL(url)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 const ExternalRedirect = ({ t }) => {
   const { fileId } = useParams()
   const client = useClient()
   const { shortcutInfos, fetchStatus } = useFetchShortcut(client, fileId)
-  if (shortcutInfos) {
+  const url = shortcutInfos?.data.attributes.url
+  const isLoaded = fetchStatus === 'loaded'
+  const hasFailed =
+    fetchStatus === 'failed' || (isLoaded && (!url || !isNavigableUrl(url)))
+  if (isLoaded && !hasFailed) {
     // eslint-disable-next-line react-hooks/immutability
-    window.location.href = shortcutInfos.data.attributes.url
+    window.location.href = url
   }
 
   return (
     <DummyLayout>
-      {fetchStatus === 'failed' && (
+      {hasFailed && (
         <Empty
           data-testid="empty-share"
           icon={EmptyIcon}
@@ -28,7 +41,7 @@ const ExternalRedirect = ({ t }) => {
           text={t('External.redirection.error')}
         />
       )}
-      {fetchStatus !== 'failed' && (
+      {!hasFailed && (
         <Empty
           data-testid="empty-share"
           icon={Globe}


### PR DESCRIPTION
Forbid to redirect shortcut to something else than an http or https link.

No consequence in production thanks to our CSP let's fix it anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - External redirects now validate HTTP and HTTPS addresses before navigating.
  - Invalid or unavailable redirect destinations are handled gracefully with an error state instead of attempting navigation.
  - Fetch failures now consistently display an error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->