### PR TITLE
fix: Add noopener noreferrer to some window.open

### DIFF
--- a/src/modules/navigation/components/FileLink.tsx
+++ b/src/modules/navigation/components/FileLink.tsx
@@ -11,7 +11,9 @@ interface FileLinkProps {
 
 const FileLink = forwardRef<HTMLAnchorElement, FileLinkProps>(
   function FileLinkComponent({ link, children, ...props }, ref) {
-    const openInNewTab = link.openInNewTab ? { target: '_blank' } : {}
+    const openInNewTab = link.openInNewTab
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : {}
 
     if (link.app === 'drive') {
       return (

--- a/src/modules/navigation/hooks/useFileLink.tsx
+++ b/src/modules/navigation/hooks/useFileLink.tsx
@@ -179,7 +179,7 @@ const useFileLink = (
         evt.shiftKey ||
         shouldBeOpenedInNewTab
       ) {
-        window.open(href, '_blank')
+        window.open(href, '_blank', 'noopener,noreferrer')
       } else if (app === 'drive') {
         navigate(to)
       } else {

--- a/src/modules/nextcloud/components/actions/openWithinNextcloud.jsx
+++ b/src/modules/nextcloud/components/actions/openWithinNextcloud.jsx
@@ -15,7 +15,7 @@ export const openWithinNextcloud = ({ t }) => {
     icon,
     displayCondition: docs => docs.length === 1,
     action: docs => {
-      window.open(docs[0].links.self, '_blank')
+      window.open(docs[0].links.self, '_blank', 'noopener,noreferrer')
     },
     Component: forwardRef(function OpenWithinNextcloud(props, ref) {
       return (

--- a/src/modules/nextcloud/components/actions/shareNextcloudFile.jsx
+++ b/src/modules/nextcloud/components/actions/shareNextcloudFile.jsx
@@ -15,7 +15,7 @@ const shareNextcloudFile = ({ t }) => {
     icon,
     displayCondition: docs => docs.length === 1,
     action: docs => {
-      window.open(docs[0].links.self, '_blank')
+      window.open(docs[0].links.self, '_blank', 'noopener,noreferrer')
     },
     Component: forwardRef(function Share(props, ref) {
       return (


### PR DESCRIPTION
Avoid potential reverse tabnabbing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved the security of links opened in new tabs or windows by preventing the opened page from accessing the originating page.
  * Applied this protection to file links and Nextcloud actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->